### PR TITLE
Suggestion for "Artboard > Resize to Fit Height" and "Type > Resize to Fit Text Height"

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Resize_to_Fit_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Resize_to_Fit_Height.cocoascript
@@ -24,11 +24,14 @@ var onRun = function(context) {
     var loopSelection = selection.objectEnumerator();
     var layer;
     while (layer = loopSelection.nextObject()) {
-        if (layer.class() == "MSArtboardGroup" || layer.class() == "MSSymbolMaster") {
-            var rectOfChildLayers = getRectFromLayers(layer);
-            var height = Math.ceil(rectOfChildLayers.y() + rectOfChildLayers.height());
-            layer.frame().setHeight(height);
+        if (layer.class() != "MSArtboardGroup" && layer.class() != "MSSymbolMaster") {
+          layer = findParentArtboard(layer);
         }
+        var rectOfChildLayers = getRectFromLayers(layer);
+        var height = Math.ceil(rectOfChildLayers.y() + rectOfChildLayers.height());
+        layer.frame().setHeight(height);
+
+        layer.select_byExtendingSelection(true, false);
     }
 
     ga(context, "UA-99098773-3", "Artboard", context.command.identifier());
@@ -50,4 +53,11 @@ function getRectFromLayers(parentGroup) {
     // Return {x, y, width, height}
     return rect;
 
+}
+
+function findParentArtboard(layer) {
+    do {
+        layer = layer.parentGroup();
+    } while  (layer.class() != "MSArtboardGroup" && layer.class() != "MSSymbolMaster")
+    return layer;
 }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Resize_Fit_Text_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Resize_Fit_Text_Height.cocoascript
@@ -58,6 +58,7 @@ var onRun = function(context) {
 
                 layer.frame().setWidth(originalWidth);
 
+                layer.setTextBehaviour(1);
             }
         }
 


### PR DESCRIPTION
CHANGED "Artboard > Resize to Fit Height" so you don't have to select the Artboard first. Any layer inside an Artboard will do and it automatically finds the Artboard and resizes it.

CHANGED "Type > Resize to Fit Text Height" so the text behaviour is set back to "fixed" after resetting its height.

What do you think about it? Like it?