### PR TITLE
Change "Remove redundant groups" to remove also groups that only contain one single layer.

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Redundant_Groups.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Redundant_Groups.cocoascript
@@ -24,12 +24,12 @@ var onRun = function(context) {
 function removeRedundantGroups(layer) {
     if (layer.class() == "MSLayerGroup") {
         // Ungroup Redundant Groups
-        if (layer.layers().count() == 1 && layer.layers().firstObject().class() == "MSLayerGroup") {
+        if (layer.layers().count() == 1) {
             var child = layer.layers().firstObject();
             if(groupIsSafeToUngroup(layer)) {
                 layer.ungroup();
             }
-            removeRedundantGroups(child);
+            if (child.class() == "MSLayerGroup") {removeRedundantGroups(child);}
         } else {
             for (var i = 0; i < layer.layers().count(); i++) {
                 var childLayer = layer.layers().objectAtIndex(i);


### PR DESCRIPTION
Change "Remove redundant groups" to remove also groups that only contain one single layer.

Sometimes during the design process you end up with groups that only contain one single layer. As long there is no styling applied to the groups, these groups are not necessary and can be removed/ungrouped.

This:
![bildschirmfoto 2018-05-30 um 18 50 24](https://user-images.githubusercontent.com/10092794/40735298-1dc1ab82-643b-11e8-9e66-b52cf2520b9b.png)

Becomes this:
![bildschirmfoto 2018-05-30 um 18 50 49](https://user-images.githubusercontent.com/10092794/40735310-2645bfaa-643b-11e8-96d4-319cf65d92aa.png)

