### PR TITLE
Copy cleanup

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Kind.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Kind.cocoascript
@@ -7,7 +7,7 @@ var onRun = function(context) {
     var document = context.document;
     var selection = context.selection;
     if (selection.count() == 0) {
-        document.showMessage("Please select at least 2 layer.");
+        document.showMessage("Please select at least 2 layers.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Name.cocoascript
@@ -7,7 +7,7 @@ var onRun = function(context) {
     var document = context.document;
     var selection = context.selection;
     if (selection.count() == 0) {
-        document.showMessage("Please select at least 2 layer.");
+        document.showMessage("Please select at least 2 layers.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Position_XY.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Order_Layers_by_Position_XY.cocoascript
@@ -45,7 +45,7 @@ function orderLayers(context, position) {
         tempLayer.removeFromParent();
 
     } else {
-        doc.showMessage("You need to select at least 2 layers.");
+        doc.showMessage("Please select at least 2 layers.");
     }
 
     ga(context, "Arrange");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Reverse_Layer_Order.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Reverse_Layer_Order.cocoascript
@@ -23,7 +23,7 @@ var onRun = function(context) {
     
 
     } else {
-        document.showMessage("You need to select at least 2 layers.");
+        document.showMessage("Please select at least 2 layers.");
     }
 
     ga(context, "Arrange");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_Navigator.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_Navigator.cocoascript
@@ -11,7 +11,7 @@ var onRun = function(context) {
     var allArtboards = document.documentData().allArtboards();
 
     if (allArtboards.count() == 0) {
-        document.showMessage("No any artboard in current document.");
+        document.showMessage("No artboards in current document.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_to_Group.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_to_Group.cocoascript
@@ -11,7 +11,7 @@ var onRun = function(context) {
     var artboardsInSelection = selection.filteredArrayUsingPredicate(predicate);
 
     if (artboardsInSelection.count() == 0) {
-        document.showMessage("Select a artboard first.");
+        document.showMessage("Select artboard first.");
     }
 
     var loopArtboards = artboardsInSelection.objectEnumerator();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.cocoascript
@@ -22,7 +22,7 @@ var onRun = function(context) {
     // Dialog
     var dialog = COSAlertWindow.alloc().init();
     dialog.setMessageText("Export All Artboards");
-    dialog.setInformativeText("Export all artboards, symbol master or both of them.");
+    dialog.setInformativeText("Export all artboards, symbol masters or both.");
     dialog.addButtonWithTitle("OK");
     dialog.addButtonWithTitle("Cancel");
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var documentData = doc.documentData();
 
     if (documentData.allArtboards().count() == 0) {
-        doc.showMessage("Document have no any artboard.");
+        doc.showMessage("No artboards in current document.");
         return;
     }
 
@@ -72,10 +72,10 @@ var onRun = function(context) {
                 panelMessage = "Export All Artboards To ...";
                 break;
             case 1:
-                panelMessage = "Export All Symbol Master To ...";
+                panelMessage = "Export All Symbol Masters To ...";
                 break;
             case 2:
-                panelMessage = "Export All Artboards And Symbol Master To ...";
+                panelMessage = "Export All Artboards And Symbol Masters To ...";
                 break;
             default:
                 panelMessage = "Export All Artboards To ...";

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards_to_HTML.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards_to_HTML.cocoascript
@@ -111,7 +111,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Document have no any artboard.");
+        doc.showMessage("No artboards in current document.");
     }
 
     ga(context, "Artboard");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards_to_HTML.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards_to_HTML.cocoascript
@@ -9,7 +9,7 @@ var onRun = function(context) {
         // Dialog
         var dialog = COSAlertWindow.alloc().init();
         dialog.setMessageText("Export All Artboards to HTML");
-        dialog.setInformativeText("Choose the image format.\nThe artboard whitch is named begin with \".\" will be ignored.");
+        dialog.setInformativeText("Choose the image format.\nArtboards beginning with \".\" will be ignored.");
         dialog.addButtonWithTitle("OK");
         dialog.addButtonWithTitle("Cancel");
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Move_Artboards_to_Bottom_of_Another.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Move_Artboards_to_Bottom_of_Another.cocoascript
@@ -19,7 +19,7 @@ var onRun = function(context) {
     }
 
     if (selectedArtboards.count() == 0) {
-        doc.showMessage("Please select at least one artboard.");
+        doc.showMessage("Please select at least 1 artboard.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Resize_to_Fit_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Resize_to_Fit_Height.cocoascript
@@ -15,7 +15,7 @@ var onRun = function(context) {
             var height = Math.ceil(rectOfChildLayers.y() + rectOfChildLayers.height());
             artboard.frame().setHeight(height);
         } else {
-            doc.showMessage('"' + layer.name() + '" is not an Artboard or not inside an Artboard.');
+            doc.showMessage('"' + layer.name() + '" is not an artboard or not inside an artboard.');
         }
 
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Data/Export_Data_From_Symbol_Instances.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Data/Export_Data_From_Symbol_Instances.cocoascript
@@ -35,7 +35,7 @@ var onRun = function(context) {
     }
 
     if (Object.keys(overrideData).length == 0) {
-        document.showMessage("Not any override in selection.");
+        document.showMessage("No overrides available in selection.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Data/Export_Image_From_Layers.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Data/Export_Image_From_Layers.cocoascript
@@ -31,7 +31,7 @@ var onRun = function(context) {
     }
 
     if (images.count() == 0) {
-        document.showMessage("Not any image-fill or bitmap layer in selection.");
+        document.showMessage("No image-fill or bitmap layers in selection.");
         return;
     }
     

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_ObjectID_or_SymbolID.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_ObjectID_or_SymbolID.cocoascript
@@ -46,7 +46,7 @@ var onRun = function(context) {
         }
 
     } else {
-        document.showMessage("Please select one layer.");
+        document.showMessage("Please select 1 layer.");
     }
 
     ga(context, "Development");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_ObjectID_or_SymbolID.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_ObjectID_or_SymbolID.cocoascript
@@ -22,7 +22,7 @@ var onRun = function(context) {
         pboard.clearContents();
         pboard.setString_forType_(pasteboardContent, NSStringPboardType);
 
-        document.showMessage('Layer objectID/SymbolID has copied.');
+        document.showMessage('Layer objectID/SymbolID copied.');
 
     } else if (selection.count() == 1) {
 
@@ -36,13 +36,13 @@ var onRun = function(context) {
                 NSMutableString.stringWithString(layer.symbolID()),
                 NSStringPboardType
             );
-            document.showMessage('SymbolID "' + layer.symbolID() + '" has copied.');
+            document.showMessage('SymbolID "' + layer.symbolID() + '" copied.');
         } else {
             pboard.setString_forType_(
                 NSMutableString.stringWithString(layer.objectID()),
                 NSStringPboardType
             );
-            document.showMessage('Layer objectID "' + layer.objectID() + '" has copied.');
+            document.showMessage('Layer objectID "' + layer.objectID() + '" copied.');
         }
 
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Selected_Layer_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Selected_Layer_Name.cocoascript
@@ -22,9 +22,9 @@ var onRun = function(context) {
         pboard.setString_forType_(pasteBoardString, NSStringPboardType);
 
         if (selection.count() > 1) {
-            document.showMessage(selection.count() + " layer names has copied.");
+            document.showMessage(selection.count() + " layer names copied.");
         } else {
-            document.showMessage("Layer names has copied.");
+            document.showMessage("Layer names copied.");
         }
 
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Selected_Layer_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Selected_Layer_Name.cocoascript
@@ -28,7 +28,7 @@ var onRun = function(context) {
         }
 
     } else {
-        document.showMessage("Please select at least one layer.");
+        document.showMessage("Please select at least 1 layer.");
     }
 
     ga(context, "Development");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Slice_As_Base64.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Copy_Slice_As_Base64.cocoascript
@@ -42,7 +42,7 @@ var onRun = function(context) {
         pboard.clearContents();
         pboard.setString_forType_(base64Code, NSStringPboardType);
 
-        doc.showMessage("The base64 code \"" + base64Preview + "\" of slice has copied.");
+        doc.showMessage("The base64 code \"" + base64Preview + "\" of slice copied.");
 
     } else {
         doc.showMessage("Please select 1 slice layer.");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Open_Finder_or_Terminal.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Open_Finder_or_Terminal.cocoascript
@@ -3,7 +3,7 @@
 var showFileInFinder = function(context) {
     var doc = context.document;
     if (!doc.fileURL()) {
-        doc.showMessage("You have to save this document.");
+        doc.showMessage("Please save this document first.");
     } else {
         var filePath = doc.fileURL().path();
         NSWorkspace.sharedWorkspace().selectFile_inFileViewerRootedAtPath(filePath, nil);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Pick_Color_And_Copy_To_Pasteboard.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Pick_Color_And_Copy_To_Pasteboard.cocoascript
@@ -25,7 +25,7 @@ var onRun = function(context) {
         pboard.clearContents();
         pboard.setString_forType_(hexValue, NSStringPboardType);
 
-        document.showMessage("The color code \"" + hexValue + "\" has been copied.");
+        document.showMessage("Color code \"" + hexValue + "\" copied.");
 
         coscript.setShouldKeepAround(false);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Show_Layer_Info.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Show_Layer_Info.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     if (selection.count() == 0) {
-        document.showMessage("Please select at least one layer.");
+        document.showMessage("Please select at least 1 layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Show_Layer_Info.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Show_Layer_Info.cocoascript
@@ -200,5 +200,5 @@ function copyToPasteboard(context, cotentString) {
     var pboard = NSPasteboard.generalPasteboard();
     pboard.clearContents();
     pboard.setString_forType_(cotentString, NSStringPboardType);
-    context.document.showMessage("ID \"" + cotentString + "\" has copied.");
+    context.document.showMessage("ID \"" + cotentString + "\" copied.");
 }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Grid_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Grid_Setting.cocoascript
@@ -15,7 +15,7 @@ var copyGrid = function(context) {
             if (layer.grid()) {
                 copyGridToPasteboard(context, layer);
             } else {
-                document.showMessage("There is not grid setting in \"" + layer.name() + "\".");
+                document.showMessage("No grid setting in \"" + layer.name() + "\".");
                 return;
             }
         } else {
@@ -27,7 +27,7 @@ var copyGrid = function(context) {
         if (page.grid() && page.artboards().count() == 0) {
             copyGridToPasteboard(context, page);
         } else {
-            document.showMessage("There is not grid setting in \"" + page.name() + "\".");
+            document.showMessage("No grid setting in \"" + page.name() + "\".");
             return;
         }
     }
@@ -87,7 +87,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The grid setting copied.");
+    context.document.showMessage("Grid setting copied.");
 }
 
 function getStringFromPasteboard(context) {
@@ -98,7 +98,7 @@ function getStringFromPasteboard(context) {
         if (string) {
             return string;
         } else {
-            context.document.showMessage("Clipboard have not any grid setting.");
+            context.document.showMessage("No grid setting in clipboard.");
             return nil;
         }
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Grid_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Grid_Setting.cocoascript
@@ -87,7 +87,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The grid setting has copied.");
+    context.document.showMessage("The grid setting copied.");
 }
 
 function getStringFromPasteboard(context) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Guide_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Guide_Setting.cocoascript
@@ -22,7 +22,7 @@ var copyGuide = function(context) {
         if (page.artboards().count() == 0) {
             copyGuideToPasteboard(context, page);
         } else {
-            document.showMessage("There is not guide setting in \"" + page.name() + "\".");
+            document.showMessage("No guide setting in \"" + page.name() + "\".");
             return;
         }
     }
@@ -78,7 +78,7 @@ function copyGuideToPasteboard(context, layer) {
         layer.horizontalRulerData().guides().count() == 0 &&
         layer.verticalRulerData().guides().count() == 0
     ) {
-        document.showMessage("There is not guide setting in \"" + layer.name() + "\".");
+        document.showMessage("No guide setting in \"" + layer.name() + "\".");
         return;
     } else {
         var horizontalRulerData = layer.horizontalRulerData().guides().componentsJoinedByString(",");
@@ -103,7 +103,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The guide setting copied.");
+    context.document.showMessage("Guide setting copied.");
 }
 
 function getStringFromPasteboard(context) {
@@ -114,7 +114,7 @@ function getStringFromPasteboard(context) {
         if (string) {
             return string;
         } else {
-            context.document.showMessage("Clipboard have not any guide setting.");
+            context.document.showMessage("No grid setting in clipboard.");
             return nil;
         }
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Guide_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Guide_Setting.cocoascript
@@ -103,7 +103,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The guide setting has copied.");
+    context.document.showMessage("The guide setting copied.");
 }
 
 function getStringFromPasteboard(context) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Layout_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Layout_Setting.cocoascript
@@ -15,11 +15,11 @@ var copyLayout = function(context) {
             if (layer.layout()) {
                 copyLayoutToPasteboard(context, layer);
             } else {
-                document.showMessage("There is not layout setting in \"" + layer.name() + "\".");
+                document.showMessage("No layout setting in \"" + layer.name() + "\".");
                 return;
             }
         } else {
-            document.showMessage("The layer \"" + layer.name() + "\" is not a artboard.");
+            document.showMessage("The layer \"" + layer.name() + "\" is not an artboard.");
             return;
         }
     } else {
@@ -27,7 +27,7 @@ var copyLayout = function(context) {
         if (page.layout() && page.artboards().count() == 0) {
             copyLayoutToPasteboard(context, page);
         } else {
-            document.showMessage("There is not layout setting in \"" + page.name() + "\".");
+            document.showMessage("No layout setting in \"" + page.name() + "\".");
             return;
         }
     }
@@ -110,7 +110,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The layout setting copied.");
+    context.document.showMessage("Layout setting copied.");
 }
 
 function getStringFromPasteboard(context) {
@@ -121,7 +121,7 @@ function getStringFromPasteboard(context) {
         if (string) {
             return string;
         } else {
-            context.document.showMessage("Clipboard have not any layout setting.");
+            context.document.showMessage("No layout setting in clipboard.");
             return nil;
         }
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Layout_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Copy_and_Paste_Layout_Setting.cocoascript
@@ -110,7 +110,7 @@ function copyStringToPasteboard(context, string) {
     var pasteboard = NSPasteboard.generalPasteboard();
     pasteboard.clearContents();
     pasteboard.setString_forType(NSMutableString.stringWithString(string), NSPasteboardTypeString);
-    context.document.showMessage("The layout setting has copied.");
+    context.document.showMessage("The layout setting copied.");
 }
 
 function getStringFromPasteboard(context) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Grid_Setting.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Grid_Setting.cocoascript
@@ -11,7 +11,7 @@ var onRun = function(context) {
     var selectedArtboards = selection.filteredArrayUsingPredicate(predicate);
 
     if (selectedArtboards.count() == 0) {
-        document.showMessage("Please select a Artboard or Symbol Master.");
+        document.showMessage("Please select an artboard or symbol master.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Hide_All_Grid.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Hide_All_Grid.cocoascript
@@ -17,7 +17,7 @@ var onRun = function(context) {
     }
 
     if (selectedArtboards.count() == 0) {
-        document.showMessage("Please select a Artboard or Symbol Master.");
+        document.showMessage("Please select an artboard or symbol master.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Guide/Hide_All_Layout.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Guide/Hide_All_Layout.cocoascript
@@ -17,7 +17,7 @@ var onRun = function(context) {
     }
 
     if (selectedArtboards.count() == 0) {
-        document.showMessage("Please select a Artboard or Symbol Master.");
+        document.showMessage("Please select an artboard or symbol master.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Adjust_Sizes.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Adjust_Sizes.cocoascript
@@ -103,7 +103,7 @@ function runActionForSelection(context, action) {
     var document = context.document;
     var selection = context.selection;
     if (selection.count() == 0) {
-        document.showMessage("Please select at least one layer.");
+        document.showMessage("Please select at least 1 layer.");
         return;
     }
     var loopSelection = selection.objectEnumerator();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Clear_Layer_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Clear_Layer_Name.cocoascript
@@ -25,11 +25,11 @@ var onRun = function(context) {
 
     var message;
     if (count > 1) {
-        message = "🎉 " + count + " \"copy\"s have been removed.";
+        message = "🎉 " + count + " \"copy\"s removed.";
     } else if (count == 1) {
-        message = "😊 1 \"copy\" have been removed.";
+        message = "😊 1 \"copy\" removed.";
     } else {
-        message = "👍 Your document have no any \"copy\".";
+        message = "👍 Your document has no \"copy\".";
     }
     doc.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Divide_Layer.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Divide_Layer.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     if (selection.count() != 1) {
-        doc.showMessage("Please select one shape layer.");
+        doc.showMessage("Please select 1 shape layer.");
     }
 
     var layer = selection.firstObject();
@@ -65,7 +65,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select one shape layer.");
+        doc.showMessage("Please select 1 shape layer.");
     }
 
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Empty_Groups.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Empty_Groups.cocoascript
@@ -26,11 +26,11 @@ var onRun = function(context) {
 
     var message;
     if (count > 1) {
-        message = "🎉 " + count + " empty groups have been removed.";
+        message = "🎉 " + count + " empty groups removed.";
     } else if (count == 1) {
-        message = "😊 1 empty group have been removed.";
+        message = "😊 1 empty group removed.";
     } else {
-        message = "👍 Your document have no any empty group.";
+        message = "👍 Your document has no empty group.";
     }
     doc.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Hidden_Layers.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Hidden_Layers.cocoascript
@@ -25,11 +25,11 @@ var onRun = function(context) {
 
     var message;
     if (count > 1) {
-        message = "🎉 " + count + " hidden layers have been removed.";
+        message = "🎉 " + count + " hidden layers removed.";
     } else if (count == 1) {
-        message = "😊 1 hidden layer have been removed.";
+        message = "😊 1 hidden layer removed.";
     } else {
-        message = "👍 Your document have no any hidden layer.";
+        message = "👍 Your document has no hidden layers.";
     }
     doc.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Child_Layers.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Child_Layers.cocoascript
@@ -38,7 +38,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one group or artboard.");
+        doc.showMessage("Please select at least 1 group or artboard.");
     }
 
     ga(context, "Layer");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.cocoascript
@@ -117,7 +117,7 @@ function selectLayersInSelectionByType(context, type) {
     }
 
     if (totalCount == 0) {
-        doc.showMessage(`No ${type} layer found.`);
+        doc.showMessage(`No ${type} layers found.`);
     } else if (totalCount == 1) {
         doc.showMessage(`Select 1 ${type} layer.`);
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.cocoascript
@@ -77,7 +77,7 @@ var selectAllExportableInSelection = function(context) {
     }
 
     if (totalCount == 0) {
-        doc.showMessage("No exportable layer found.");
+        doc.showMessage("No exportable layers found.");
     } else if (totalCount == 1) {
         doc.showMessage("Select 1 exportable layer.");
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_Outside_Of_Artboard_Bounds.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_Outside_Of_Artboard_Bounds.cocoascript
@@ -44,14 +44,14 @@ var onRun = function(context) {
     });
 
     if (artboardCount == 0) {
-        document.showMessage("This document have no any artboard.");
+        document.showMessage("This document has no artboards.");
         return;
     }
 
     if (layerCount > 0) {
-        document.showMessage(`Select ${layerCount} layer(s) in ${artboardCount} artbard(s) and ${pageCount} page(s).`);
+        document.showMessage(`Select ${layerCount} layer(s) in ${artboardCount} artboard(s) and ${pageCount} page(s).`);
     } else {
-        document.showMessage("No any layer outside of artboard bounds.");
+        document.showMessage("No layers outside of artboard bounds.");
     }
 
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Parent_Groups.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Parent_Groups.cocoascript
@@ -37,7 +37,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one layer.");
+        doc.showMessage("Please select at least 1 layer.");
     }
     ga(context, "Layer");
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Reverse.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Reverse.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     if (selection.count() == 0) {
-        document.showMessage("Please select at least one layer.");
+        document.showMessage("Please select at least 1 layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Reverse.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Reverse.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     if (selection.count() == 0) {
-        document.showMessage("Please select at least 1 layer.");
+        document.showMessage("Please select at least one layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_or_Remove_All_Transparency_Layers.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_or_Remove_All_Transparency_Layers.cocoascript
@@ -29,11 +29,11 @@ var removeTransparencyLayersHandler = function(context) {
 
     var message;
     if (count > 1) {
-        message = "🎉 " + count + " transparency layers have been removed.";
+        message = "🎉 " + count + " transparency layers removed.";
     } else if (count == 1) {
-        message = "😊 1 transparency layer have been removed.";
+        message = "😊 1 transparency layer removed.";
     } else {
-        message = "👍 Your document have no any transparency layer.";
+        message = "👍 Your document has no transparency layers.";
     }
     document.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Toggle_Layer_Constrain_Proportions.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Toggle_Layer_Constrain_Proportions.cocoascript
@@ -25,13 +25,13 @@ var onRun = function(context) {
         selection.forEach(function(layer){
             layer.setConstrainProportions(true);
         });
-        document.showMessage("Layer constrain proportions LOCK");
+        document.showMessage("Layer constrain proportions set to LOCK");
     }
     else {
         selection.forEach(function(layer){
             layer.setConstrainProportions(false);
         });
-        document.showMessage("Layer constrain proportions UNLOCK");
+        document.showMessage("Layer constrain proportions set to UNLOCK");
     }
 
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Toggle_Select_Groups_Content_On_Click.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Toggle_Select_Groups_Content_On_Click.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var predicate = NSPredicate.predicateWithFormat("className == %@", "MSLayerGroup");
     var selectedGroups = selection.filteredArrayUsingPredicate(predicate);
     if (selectedGroups.count() == 0) {
-        document.showMessage("Please select at least one layer group.");
+        document.showMessage("Please select at least 1 layer group.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Ungroup_Shape_Layer.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Ungroup_Shape_Layer.cocoascript
@@ -17,7 +17,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one shape layer.");
+        doc.showMessage("Please select at least 1 shape layer.");
     }
 
     ga(context, "Layer");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.cocoascript
@@ -175,7 +175,7 @@ var onRun = function(context) {
         if (allMatchStyles.length == 0) {
             var contentView = NSView.alloc().initWithFrame(NSMakeRect(0, 0, 300, 260));
             contentView.setFlipped(true);
-            var noStyleTipView = UI.textLabel(`No any match ${styleType} styles in this library.`, [0, 120, 300, 30]);
+            var noStyleTipView = UI.textLabel(`No matching ${styleType} styles in this library.`, [0, 120, 300, 30]);
             noStyleTipView.setTextColor(NSColor.grayColor());
             noStyleTipView.setAlignment(NSCenterTextAlignment);
             contentView.addSubview(noStyleTipView);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.cocoascript
@@ -7,7 +7,7 @@ var onRun = function(context) {
 
     var document = context.document;
     if (MSApplicationMetadata.metadata().appVersion < 51) {
-        document.showMessage("😮 You have to update Sketch 51+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 51+ to use thie feature.");
         return;
     }
 
@@ -26,21 +26,21 @@ var onRun = function(context) {
         styleType = "layer";
     }
     if (allLocalStyle.count() == 0) {
-        document.showMessage(`No any ${styleType} styles in current document.`);
+        document.showMessage(`No ${styleType} styles in current document.`);
         return;
     }
 
     var assetLibraryController = AppController.sharedInstance().librariesController();
     var availableLibraries = assetLibraryController.availableLibraries();
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 
     // Dialog
     var dialog = UI.cosDialog(
         `Change Local ${capitalize(styleType)} Style to Library ${capitalize(styleType)} Style`,
-        `Change the following local ${styleType} styles to change it to foreign ${styleType} style from library.`,
+        `Change the following local ${styleType} styles to to foreign ${styleType} style from library.`,
         ["OK", "Cancel"]
     );
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Symbols_to_Library_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Symbols_to_Library_Symbol.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var documentData = document.documentData();
 
     if (MSApplicationMetadata.metadata().appVersion < 47) {
-        document.showMessage("😮 You have to update Sketch 47+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
 
@@ -17,7 +17,7 @@ var onRun = function(context) {
     var availableLibraries = assetLibraryController.availableLibraries();
 
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 
@@ -52,9 +52,9 @@ var onRun = function(context) {
 
     if (symbolMastersWillChanged.count() == 0) {
         if (selection.count() > 0) {
-            document.showMessage("You have not select any symbol.");
+            document.showMessage("You have not selected any symbol.");
         } else {
-            document.showMessage("Current document have not any symbol.");
+            document.showMessage("Current document has no symbols.");
         }
         return;
     }
@@ -157,11 +157,11 @@ var onRun = function(context) {
 
     var message;
     if (countSymbol > 1) {
-        message = countSymbol + " symbol masters have been changed to library symbol.";
+        message = countSymbol + " symbol masters changed to library symbol.";
     } else if (countSymbol == 1) {
-        message = "1 symbol master have been changed to library symbol.";
+        message = "1 symbol master changed to library symbol.";
     } else {
-        message = "No any symbol master have been changed to library symbol.";
+        message = "No symbol masters changed to library symbol.";
     }
     document.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.cocoascript
@@ -32,7 +32,7 @@ var onRun = function(context) {
 
     var dialog = NSAlert.alloc().init();
     dialog.setMessageText("Fix Library ID Conflict");
-    dialog.setInformativeText("Change the library ID, will cause symbol's auto update broken.");
+    dialog.setInformativeText("Change the library ID, will cause symbol's auto update to break.");
     dialog.addButtonWithTitle("Cancel");
 
     var accessoryView = NSView.alloc().init();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.cocoascript
@@ -7,19 +7,19 @@ var onRun = function(context) {
     var document = context.document;
 
     if (MSApplicationMetadata.metadata().appVersion < 48) {
-        document.showMessage("😮 You have to update Sketch 48+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 48+ to use thie feature.");
         return;
     }
 
     var libraries = librariesWithConflictID();
 
     if (!libraries) {
-        document.showMessage("You have not any library.");
+        document.showMessage("You have no libraries.");
         return;
     }
 
     if (libraries.count() == 0) {
-        document.showMessage("😀 You have not any library with conflict ID.");
+        document.showMessage("😀 You have no libraries with conflict ID.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Document_Assets_from_Library.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Document_Assets_from_Library.cocoascript
@@ -6,7 +6,7 @@ var onRun = function(context) {
 
     var document = context.document;
     if (MSApplicationMetadata.metadata().appVersion < 47) {
-        document.showMessage("😮 You have to update Sketch 47+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
 
@@ -14,7 +14,7 @@ var onRun = function(context) {
     var availableLibraries = assetLibraryController.availableLibraries();
 
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Styles_from_Library.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Styles_from_Library.cocoascript
@@ -6,7 +6,7 @@ var onRun = function(context) {
 
     var document = context.document;
     if (MSApplicationMetadata.metadata().appVersion < 47) {
-        document.showMessage("😮 You have to update Sketch 47+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
 
@@ -14,7 +14,7 @@ var onRun = function(context) {
     var availableLibraries = assetLibraryController.availableLibraries();
 
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 
@@ -38,7 +38,7 @@ var onRun = function(context) {
     var checkboxTextStyle = checkboxView("Import text styles.");
     dialog.addAccessoryView(checkboxTextStyle);
 
-    var checkboxLayerStyle = checkboxView("Import layer style.");
+    var checkboxLayerStyle = checkboxView("Import layer styles.");
     dialog.addAccessoryView(checkboxLayerStyle);
 
     // Run

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Imported_Symbols_Link_Manage.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Imported_Symbols_Link_Manage.cocoascript
@@ -6,21 +6,21 @@ var onRun = function(context) {
 
     var document = context.document;
     if (MSApplicationMetadata.metadata().appVersion < 47) {
-        document.showMessage("😮 You have to update Sketch 47+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
 
     var documentData = document.documentData();
     var allImportedSymbols = documentData.foreignSymbols();
     if (allImportedSymbols.count() == 0) {
-        document.showMessage("You have not any imported symbol.");
+        document.showMessage("You have no imported symbols.");
         return;
     }
 
     var assetLibraryController = AppController.sharedInstance().librariesController();
     var availableLibraries = assetLibraryController.availableLibraries();
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 
@@ -42,7 +42,7 @@ var onRun = function(context) {
     // Dialog
     var dialog = NSAlert.alloc().init();
     dialog.setMessageText("Imported Symbols Link Manage");
-    dialog.setInformativeText("Link imported symbols to another library, or fix the library not found error.");
+    dialog.setInformativeText("Link imported symbols to another library, or fix the 'Library not found' error.");
     dialog.addButtonWithTitle("Close");
 
     var accessoryView = NSView.alloc().init();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Library.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Library.cocoascript
@@ -11,13 +11,13 @@ var onRun = function(context) {
     var assetLibraryController = AppController.sharedInstance().librariesController();
     var allLibraries = assetLibraryController.libraries();
     if (allLibraries.count() == 0) {
-        document.showMessage('These is not any library in "Preferences" - "Libraries".');
+        document.showMessage('These are no libraries in "Preferences" - "Libraries".');
         return;
     }
 
     var foreignSymbols = documentData.foreignSymbols();
     if (foreignSymbols.count() == 0) {
-        document.showMessage("Current document have not use any library.");
+        document.showMessage("Current document is not using any libraries.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var documentData = document.documentData();
 
     if (MSApplicationMetadata.metadata().appVersion < 47) {
-        document.showMessage("😮 You have to update Sketch 47+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
 
@@ -17,12 +17,12 @@ var onRun = function(context) {
     var availableLibraries = assetLibraryController.availableLibraries();
 
     if (documentData.localSymbols().count() == 0) {
-        document.showMessage("Current document have not any local symbol.");
+        document.showMessage("Current document has no local symbols.");
         return;
     }
 
     if (availableLibraries.count() == 0) {
-        document.showMessage("You have not any available library.");
+        document.showMessage("You have no available libraries.");
         return;
     }
 
@@ -48,7 +48,7 @@ var onRun = function(context) {
     }
 
     if (!selectedSymbol) {
-        document.showMessage("You have not select any local symbol.");
+        document.showMessage("You have not selected any local symbols.");
         return;
     }
 
@@ -56,7 +56,7 @@ var onRun = function(context) {
     var dialog = COSAlertWindow.alloc().init();
     dialog.setMessageText("Replace Symbol With Library Symbol");
     dialog.setInformativeText(
-        "You current select the symbol master named \"" + selectedSymbol.name() +"\"."
+        "You currently selected the symbol master named \"" + selectedSymbol.name() +"\"."
     );
 
     var accessoryView = NSView.alloc().init();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.cocoascript
@@ -27,7 +27,7 @@ var onRun = function(context) {
     }
 
     if (selection.count() == 0) {
-        document.showMessage("Please select one symbol.");
+        document.showMessage("Please select 1 symbol.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Prototyping/Remove_All_Hotspot.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Prototyping/Remove_All_Hotspot.cocoascript
@@ -31,7 +31,7 @@ var onRun = function(context) {
         document.showMessage(`Remove ${hotspotLayerCount} hotspot layers, ${linkLayerCount} layers with link.`);
     }
     else {
-        document.showMessage("Not any hotspot layer.");
+        document.showMessage("No hotspot layers.");
     }
 
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Prototyping/Reset_Flow.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Prototyping/Reset_Flow.cocoascript
@@ -26,7 +26,7 @@ var onRun = function(context) {
     }
 
     if (showMessage) {
-        document.showMessage("Please select 1 hotspot layer or layer have a link.");
+        document.showMessage("Please select 1 hotspot layer or layer with a link.");
     }
 
 };

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Exportables.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Exportables.cocoascript
@@ -33,11 +33,11 @@ var onRun = function(context) {
 
     var message;
     if (count > 1) {
-        message = count + " exportable layers have been removed in current page.";
+        message = count + " exportable layers removed in current page.";
     } else if (count == 1) {
-        message = "1 exportable layer have been removed in current page.";
+        message = "1 exportable layer removed in current page.";
     } else {
-        message = "Not any exportable layer found in current page.";
+        message = "No exportable layers found in current page.";
     }
     doc.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Slices.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Slices.cocoascript
@@ -21,7 +21,7 @@ var onRun = function(context) {
     } else if (count == 1) {
         message = "1 slice removed in current page.";
     } else {
-        message = "Not any slice found in current page.";
+        message = "No slices found in current page.";
     }
     doc.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Slices.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Clear_Slices.cocoascript
@@ -17,9 +17,9 @@ var onRun = function(context) {
 
     var message;
     if (count > 1) {
-        message = count + " slices have been removed in current page.";
+        message = count + " slices removed in current page.";
     } else if (count == 1) {
-        message = "1 slice have been removed in current page.";
+        message = "1 slice removed in current page.";
     } else {
         message = "Not any slice found in current page.";
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Export_Presets.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Export_Presets.cocoascript
@@ -7,7 +7,7 @@ var saveExportPresetsToFile = function(context) {
     var exportPresets = MSExportPreset.allExportPresets();
 
     if (exportPresets.count() == 0) {
-        context.document.showMessage("Have not any export presets.");
+        context.document.showMessage("No export presets.");
         return;
     };
 
@@ -54,7 +54,7 @@ var saveExportPresetsToFile = function(context) {
             context.document.showMessage("Error: " + error.value());
             return;
         }
-        context.document.showMessage("Export presets save to " + filePath);
+        context.document.showMessage("Export presets saved to " + filePath);
         NSWorkspace.sharedWorkspace().selectFile_inFileViewerRootedAtPath(filePath, nil);
     }
 
@@ -117,7 +117,7 @@ var loadExportPresetsFromFile = function(context) {
         panelController.currentPreferencePane().tableView().reloadData();
         panelController.window().close();
 
-        context.document.showMessage("Export presets have loaded.");
+        context.document.showMessage("Export presets loaded.");
 
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
@@ -32,7 +32,7 @@ var runFastSlice = function(context) {
         document.showMessage("This is your first time running Fast Slice, so you need to configure the slice settings first.");
         var setting = sliceSetting(context);
         if (setting != 1000) {
-            document.showMessage("You must confirm the slice setting.");
+            document.showMessage("You must confirm the slice settings.");
             return;
         }
         if (setting == 1000) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
@@ -45,7 +45,7 @@ var runFastSlice = function(context) {
     // Checking selection
     var selection = context.selection;
     if (selection.count() == 0) {
-        document.showMessage("Please select at least one layer.");
+        document.showMessage("Please select at least 1 layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Fast_Slice.cocoascript
@@ -29,7 +29,7 @@ var runFastSlice = function(context) {
         }
     }
     if (runSettingFirst) {
-        document.showMessage("You may first time run Fast Slice, so config the slice setting first.");
+        document.showMessage("This is your first time running Fast Slice, so you need to configure the slice settings first.");
         var setting = sliceSetting(context);
         if (setting != 1000) {
             document.showMessage("You must confirm the slice setting.");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Solid_Fill_from_CSS_Color.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Solid_Fill_from_CSS_Color.cocoascript
@@ -283,7 +283,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select one shape layer.");
+        doc.showMessage("Please select 1 shape layer.");
     }
 
     ga(context, "Style");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Color_Guide.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Color_Guide.cocoascript
@@ -15,7 +15,7 @@ var onRun = function(context) {
         documentColors = document.documentData().assets().colors();
     }
     if (documentColors.count() == 0) {
-        document.showMessage("No any document color or gradient in current document.");
+        document.showMessage("No document colors or gradients in current document.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Style_Guide.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Style_Guide.cocoascript
@@ -12,14 +12,14 @@ var onRun = function(context) {
     var styles = documentData.layerStyles().sharedStyles();
 
     if (styles.count() == 0) {
-        document.showMessage("Document have no any layer style.");
+        document.showMessage("Document has no layer styles.");
         return;
     }
 
     // Dialog
     var dialog = UI.cosDialog(
         "Create Style Guide",
-        "Create style guide from layer style in document. Input the format like \"100\" or \"100x50\"."
+        "Create style guide from layer style in document. Input the format for Palette Size like \"100\" or \"100x50\"."
     );
 
     var label = UI.textLabel("Palette Size");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Typography_Guide.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Typography_Guide.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var document = context.document;
     var textStyles = document.documentData().layerTextStyles().sharedStyles();
     if (textStyles.count() == 0) {
-        document.showMessage("No any text style in current document.");
+        document.showMessage("No text styles in current document.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Fill_Color_from_Colors.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Fill_Color_from_Colors.cocoascript
@@ -24,7 +24,7 @@ function fillColorFromColors(context, colors, alertMessage) {
     var selection = context.selection;
 
     if (selection.count() == 0) {
-        doc.showMessage("Please select one Shape or Text layer.");
+        doc.showMessage("Please select 1 Shape or Text layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Fill_Color_from_Colors.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Fill_Color_from_Colors.cocoascript
@@ -4,13 +4,13 @@
 var fillColorFromGlobalColors = function(context) {
     ga(context, "Style");
     var globalColors = NSApp.delegate().globalAssets().colors();
-    fillColorFromColors(context, globalColors, "You have no any color in Global Colors.");
+    fillColorFromColors(context, globalColors, "You have no colors in Global Colors.");
 };
 
 var fillColorFromDocumentColors = function(context) {
     ga(context, "Style");
     var documentColors = context.document.documentData().assets().colors();
-    fillColorFromColors(context, documentColors, "You have no any color in Document Colors.");
+    fillColorFromColors(context, documentColors, "You have no colors in Document Colors.");
 };
 
 function fillColorFromColors(context, colors, alertMessage) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Import_Styles_from_Sketch_File.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Import_Styles_from_Sketch_File.cocoascript
@@ -34,16 +34,16 @@ var onRun = function(context) {
         if (pluginIdentifier == "import_text_styles_from_sketch_file") {
             styles = documentData.layerTextStyles();
             newStyles = newDocumentData.layerTextStyles();
-            name = "text sytle";
+            name = "text styles";
         }
         if (pluginIdentifier == "import_layer_styles_from_sketch_file") {
             styles = documentData.layerStyles();
             newStyles = newDocumentData.layerStyles();
-            name = "layer sytle";
+            name = "layer styles";
         }
 
         if (newStyles.numberOfSharedStyles() == 0) {
-            document.showMessage(`Not any ${name} in this file.`);
+            document.showMessage(`No ${name} in this file.`);
             return;
         }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Paste_Style_Part.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Paste_Style_Part.cocoascript
@@ -53,7 +53,7 @@ var onRun = function(context) {
                         }
                     }
                 } else {
-                    doc.showMessage("Style no include fills.");
+                    doc.showMessage("Style does not include fills.");
                 }
             }
 
@@ -75,7 +75,7 @@ var onRun = function(context) {
                         }
                     }
                 } else {
-                    doc.showMessage("Style no include borders.");
+                    doc.showMessage("Style does not include borders.");
                 }
             }
 
@@ -99,7 +99,7 @@ var onRun = function(context) {
                         }
                     }
                 } else {
-                    doc.showMessage("Style no include shadows.");
+                    doc.showMessage("Style does not include shadows.");
                 }
             }
 
@@ -121,7 +121,7 @@ var onRun = function(context) {
                         }
                     }
                 } else {
-                    doc.showMessage("Style no include inner shadows.");
+                    doc.showMessage("Style does not include inner shadows.");
                 }
             }
 
@@ -172,7 +172,7 @@ var onRun = function(context) {
                         }
                     }
                 } else {
-                    doc.showMessage("Style no include blur.");
+                    doc.showMessage("Style does not include blur.");
                 }
             }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     if (context.command.identifier() == "remove_unused_layer_styles") {
 
         if (documentData.layerStyles().numberOfSharedStyles() == 0) {
-            document.showMessage("Document have no any layer style.");
+            document.showMessage("Document has no layer styles.");
             return;
         }
 
@@ -21,7 +21,7 @@ var onRun = function(context) {
     if (context.command.identifier() == "remove_unused_text_styles") {
 
         if (documentData.layerTextStyles().numberOfSharedStyles() == 0) {
-            document.showMessage("Document have no any text style.");
+            document.showMessage("Document has no text styles.");
             return;
         }
 
@@ -71,14 +71,14 @@ function createDialog(context, type) {
     }
 
     if (stylesCopy.count() == 0) {
-        document.showMessage("👍 Document have no any unused " + ((type == 0) ? "layer" : "text") + " style.");
+        document.showMessage("👍 Document has no unused " + ((type == 0) ? "layer" : "text") + " styles.");
         return;
     }
 
     var dialog = COSAlertWindow.alloc().init();
     var title = (type == 0) ? "Remove Unused Layer Styles" : "Remove Unused Text Styles";
     dialog.setMessageText(title);
-    dialog.setInformativeText("You can remove unused styles from list. Uncheck to keep it.");
+    dialog.setInformativeText("You can remove unused styles from list. Uncheck styles to keep them.");
 
     var selectAllView = NSButton.alloc().initWithFrame(NSMakeRect(0, 0, 300, 20));
     selectAllView.setButtonType(NSSwitchButton);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.cocoascript
@@ -147,9 +147,9 @@ function createDialog(context, type) {
 
         var message;
         if (count > 1) {
-            message = "🎉 " + count + ((type == 0) ? " layer" : " text") + " styles have been removed.";
+            message = "🎉 " + count + ((type == 0) ? " layer" : " text") + " styles removed.";
         } else if (count == 1) {
-            message = "😊 1 " + ((type == 0) ? " layer" : " text") + " style have been removed.";
+            message = "😊 1 " + ((type == 0) ? " layer" : " text") + " style removed.";
         }
         document.showMessage(message);
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Rename_Layer_to_Style_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Rename_Layer_to_Style_Name.cocoascript
@@ -18,7 +18,7 @@ var onRun = function(context) {
     var count = selectedLayerWithSharedStyle.count();
 
     if (selection.count() == 0 || count == 0) {
-        document.showMessage("Please select a layer with shared style.");
+        document.showMessage("Please select a layer with a shared style.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Select_Layers_by_Style.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Select_Layers_by_Style.cocoascript
@@ -11,7 +11,7 @@ var selectLayersByLayerStyle = function(context) {
     if (layerStyles.count() > 0) {
         main(context, layerStyles, "Select Layers by Layer Style", "Select all layers with a layer style in current page.");
     } else {
-        document.showMessage("No any layer styles in current document.");
+        document.showMessage("No layer styles in current document.");
     }
     ga(context, "Style");
 };
@@ -27,7 +27,7 @@ var selectLayersByTextStyle = function(context) {
     if (textStyles.count() > 0) {
         main(context, textStyles, "Select Layers by Text Style", "Select all layers with a text style in current page.");
     } else {
-        document.showMessage("No any text styles in current document.");
+        document.showMessage("No text styles in current document.");
     }
     ga(context, "Style");
 };
@@ -138,7 +138,7 @@ function main(context, styles, title, message) {
             document.showMessage(`Select 1 layer with ${styleType} "${selectedStyleName}"${messageAddon}.`);
         }
         else {
-            document.showMessage(`Not any layer with ${styleType} "${selectedStyleName}"${messageAddon}.`);
+            document.showMessage(`No layers with ${styleType} "${selectedStyleName}"${messageAddon}.`);
         }
 
         NSApp.sendAction_to_from("zoomToSelection:", nil, document);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Swap_Fill_and_Border.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Swap_Fill_and_Border.cocoascript
@@ -72,7 +72,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select one layer with fill or border.");
+        doc.showMessage("Please select 1 layer with fill or border.");
     }
 
     ga(context, "Style");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Create_Symbols_from_Selected_Layers.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Create_Symbols_from_Selected_Layers.cocoascript
@@ -25,7 +25,7 @@ var onRun = function(context) {
     });
 
     if (layers.count() == 0) {
-        document.showMessage("Please select a not Artboard or Symbol Master layer.");
+        document.showMessage("Selected layer must not be an artboard or symbol master.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Detach_Unused_Symbol_Master.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Detach_Unused_Symbol_Master.cocoascript
@@ -9,7 +9,7 @@ var onRun = function(context) {
         if (!symbol.hasInstances()) {
             symbol.ungroup();
         } else {
-            doc.showMessage("This symbol master is uesed.");
+            doc.showMessage("This symbol master is used.");
         }
     } else {
         doc.showMessage("Select a symbol master.");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Export_All_Symbols_As_PNG.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Export_All_Symbols_As_PNG.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var allSymbols = document.documentData().localSymbols();
 
     if (allSymbols.count() == 0) {
-        document.showMessage("This document have no any local symbol.");
+        document.showMessage("This document has no local symbols.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Move_Symbols_To_Page.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Move_Symbols_To_Page.cocoascript
@@ -16,14 +16,14 @@ var onRun = function(context) {
 
     var symbolMasters = symbolMasterInSelection(selection);
     if (symbolMasters.count() == 0) {
-        document.showMessage("There is no any symbol master in your selection.");
+        document.showMessage("There are no symbol masters in your selection.");
         return;
     }
 
     // Dialog
     var dialog = COSAlertWindow.alloc().init();
     dialog.setMessageText("Move Symbol Masters To Another Page");
-    dialog.setInformativeText("Move selected symbol masters to anthoer page.");
+    dialog.setInformativeText("Move selected symbol masters to another page.");
     dialog.addButtonWithTitle("OK");
     dialog.addButtonWithTitle("Cancel");
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Move_Symbols_To_Page.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Move_Symbols_To_Page.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var originalPage = document.currentPage();
 
     if (selection.count() == 0) {
-        document.showMessage("Please select at least one symbol master.");
+        document.showMessage("Please select at least 1 symbol master.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.cocoascript
@@ -175,9 +175,9 @@ var onRun = function(context) {
         }
 
         if (count > 1) {
-            document.showMessage("🎉 " + count + " unused symbols have been removed.");
+            document.showMessage("🎉 " + count + " unused symbols removed.");
         } else if (count == 1) {
-            document.showMessage("😊 1 unused symbol have been removed.");
+            document.showMessage("😊 1 unused symbol removed.");
         }
 
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.cocoascript
@@ -8,14 +8,14 @@ var onRun = function(context) {
     var documentData = document.documentData();
 
     if (MSApplicationMetadata.metadata().appVersion < 48) {
-        document.showMessage("😮 You have to update Sketch 48+ to use thie feature.");
+        document.showMessage("😮 You have to update to Sketch 48+ to use thie feature.");
         return;
     }
 
     var unusedSymbols = getAllUnusedSymbols(context);
 
     if (unusedSymbols.count() == 0) {
-        document.showMessage("👍 Have not any unused symbol in current document.");
+        document.showMessage("👍 No unused symbols in current document.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Replace_Override_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Replace_Override_Symbol.cocoascript
@@ -13,17 +13,17 @@ var onRun = function(context) {
 
     var instances;
     if (selection.count() == 0) {
-        dialogMessage = "Find a override symbol from document, and replace with another."
+        dialogMessage = "Find an override symbol from document, and replace with another."
         instances = symbolInstancesInDocument(context);
         if (instances.count() == 0) {
-            document.showMessage("Not any instance in selected layers.");
+            document.showMessage("No instances in selected layers.");
             return;
         }
     } else {
-        dialogMessage = "Find a override symbol from selected layers, and replace with another."
+        dialogMessage = "Find an override symbol from selected layers, and replace with another."
         instances = symbolInstancesInSelection(context);
         if (instances.count() == 0) {
-            document.showMessage("Not any instance in document.");
+            document.showMessage("No instances in document.");
             return;
         }
     }
@@ -48,7 +48,7 @@ var onRun = function(context) {
     });
 
     if (changeableOverridePoints.count() == 0) {
-        document.showMessage("Not any symbol override.");
+        document.showMessage("No symbol overrides.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Reset_Overrides.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Reset_Overrides.cocoascript
@@ -7,7 +7,7 @@ var onRun = function(context) {
     var symbolInstancesInSelection = getSymbolInstancesInSelection(selection);
 
     if (selection.count() == 0 || symbolInstancesInSelection.count() == 0) {
-        document.showMessage("Please select at least one symbol instance.");
+        document.showMessage("Please select at least 1 symbol instance.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Select_All_Instances_of_Imported_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Select_All_Instances_of_Imported_Symbol.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var currentPage = document.currentPage();
 
     if (selection.count() != 1) {
-        document.showMessage("Please select one imported symbol.");
+        document.showMessage("Please select 1 imported symbol.");
         return;
     } else {
         var layer = selection.firstObject();
@@ -38,10 +38,10 @@ var onRun = function(context) {
                 );
 
             } else {
-                document.showMessage("Please select one imported symbol.");
+                document.showMessage("Please select 1 imported symbol.");
             }
         } else {
-            document.showMessage("Please select one imported symbol.");
+            document.showMessage("Please select 1 imported symbol.");
         }
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Select_All_Instances_of_Symbol.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Select_All_Instances_of_Symbol.cocoascript
@@ -51,7 +51,7 @@ var onRun = function(context) {
         }
 
         if (allInstancesOfCurrentSymbolMaster == 0) {
-            doc.showMessage("The symbol master has no instance.");
+            doc.showMessage("The symbol master has no instances.");
             return;
         }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Set_to_Original_Width_or_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Set_to_Original_Width_or_Height.cocoascript
@@ -9,7 +9,7 @@ var onRun = function(context) {
     var pluginIdentifier = context.command.identifier();
 
     if (selection.count() == 0) {
-        doc.showMessage("Please select at least one symbol instance.");
+        doc.showMessage("Please select at least 1 symbol instance.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_from_Sketch_File.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_from_Sketch_File.cocoascript
@@ -51,7 +51,7 @@ var onRun = function(context) {
             }
         });
         if (differentSymbols.count() == 0) {
-            document.showMessage('Symbol masters not need to update.');
+            document.showMessage('Symbol masters are the same. No need to update.');
             return;
         }
 
@@ -61,7 +61,7 @@ var onRun = function(context) {
 
         var dialog = NSAlert.alloc().init();
         dialog.setMessageText("Sync Symbol Master from Sketch File");
-        dialog.setInformativeText("Replace symbol master form file base symbolID, and import new symbol masters.");
+        dialog.setInformativeText("Replace symbol masters from file based on symbolID, and import new symbol masters.");
         dialog.addButtonWithTitle("OK");
         dialog.addButtonWithTitle("Cancel");
 
@@ -216,7 +216,7 @@ var onRun = function(context) {
 
             document.loadLayerListPanel();
 
-            document.showMessage("Update " + newSymbolMastersWillAddToDocument.count() + " symbol masters.");
+            document.showMessage("Updated " + newSymbolMastersWillAddToDocument.count() + " symbol masters.");
 
         }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_from_Sketch_File.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_from_Sketch_File.cocoascript
@@ -27,7 +27,7 @@ var onRun = function(context) {
         var newDocumentData = newDocument.documentData();
         var newDocumentSymbols = newDocumentData.localSymbols();
         if (newDocumentSymbols.count() == 0) {
-            document.showMessage('Not any symbol masters in "' + chooseFile.URL().path() + '".');
+            document.showMessage('No symbol masters in "' + chooseFile.URL().path() + '".');
             return;
         }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Add_Space_Between_CJK_and_Western_Character.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Add_Space_Between_CJK_and_Western_Character.cocoascript
@@ -26,7 +26,7 @@ var onRun = function(context) {
     }
 
     if(!hasTextLayer) {
-        doc.showMessage("Do not have any text layer.");
+        doc.showMessage("No text layer.");
     }
 
     function addSpace(textlayer) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Baseline.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Baseline.cocoascript
@@ -6,7 +6,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     if (MSApplicationMetadata.metadata().appVersion >= 48) {
-        doc.showMessage("😥 Sorry, this feature can‘t running in Sketch 48+.");
+        doc.showMessage("😥 Sorry, this feature is not compatiable with Sketch 48+.");
         return;
     }
 
@@ -23,7 +23,7 @@ var onRun = function(context) {
             selectedRange = textLayer.editingDelegate().textView().selectedRange();
 
             if (selectedRange.length == 0) {
-                doc.showMessage("Selected range have no any letter.");
+                doc.showMessage("Selected range has no letters.");
                 return;
             }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Capitalize.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Capitalize.cocoascript
@@ -23,7 +23,7 @@ var onRun = function(context) {
     }
 
     if(!hasTextLayer) {
-        doc.showMessage("Do not seleted any text layer.");
+        doc.showMessage("No text layers seleted.");
     }
 
     ga(context, "Type");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Change_Text_Orientation.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Change_Text_Orientation.cocoascript
@@ -31,7 +31,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one text layer.");
+        doc.showMessage("Please select at least 1 text layer.");
     }
 
     ga(context, "Type");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Change_Typeface_for_the_Latin_Character_Set.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Change_Typeface_for_the_Latin_Character_Set.cocoascript
@@ -15,7 +15,7 @@ var onRun = function(context) {
     var dialog = {
         "title" : "Change typeface for the Latin character set.",
         "message" : "Type the PostScript name of font. \n" +
-                    "PostScript name can be finded in \"/Applications/FontBook.app\".\n\n" +
+                    "PostScript name can be found in \"/Applications/FontBook.app\".\n\n" +
                     "Android: Roboto-Regular(Thin, Light),\n" +
                     "iOS: SFUIDisplay-Regular, \n" +
                     "Web: Arial, Helvetica, HelveticaNeue",
@@ -71,7 +71,7 @@ var onRun = function(context) {
             }
 
         } else {
-            doc.showMessage("Your selection have no include a text layer.");
+            doc.showMessage("Your selection has no text layers.");
         }
 
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Horizontally_Scale.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Horizontally_Scale.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var predicate = NSPredicate.predicateWithFormat("className == %@", "MSTextLayer");
     var selectedTextLayers = selection.filteredArrayUsingPredicate(predicate);
     if (selectedTextLayers.count() == 0) {
-        document.showMessage("Please select at least one text layer.");
+        document.showMessage("Please select at least 1 text layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Letter_Spacing.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Letter_Spacing.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var predicate = NSPredicate.predicateWithFormat("className == %@", "MSTextLayer");
     var selectedTextLayers = selection.filteredArrayUsingPredicate(predicate);
     if (selectedTextLayers.count() == 0) {
-        document.showMessage("Please select at least one text layer.");
+        document.showMessage("Please select at least 1 text layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Line_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Line_Height.cocoascript
@@ -10,7 +10,7 @@ var onRun = function(context) {
     var predicate = NSPredicate.predicateWithFormat("className == %@", "MSTextLayer");
     var selectedTextLayers = selection.filteredArrayUsingPredicate(predicate);
     if (selectedTextLayers.count() == 0) {
-        document.showMessage("Please select at least one text layer.");
+        document.showMessage("Please select at least 1 text layer.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Fonts.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Fonts.cocoascript
@@ -27,7 +27,7 @@ var onRun = function(context) {
         // Dialog
         var alert = COSAlertWindow.new();
         alert.setMessageText("Replace Fonts.");
-        alert.setInformativeText("Tips: You can find the postscript name of font from \"Font Book\" app.")
+        alert.setInformativeText("Tips: You can find the Postscript name of the font from \"Font Book\" app.")
 
         alert.addTextLabelWithValue("Choose a font used in current document:");
 
@@ -76,11 +76,11 @@ var onRun = function(context) {
 
             setPreferences(context, "replaceFont", replaceFont);
 
-            doc.showMessage('Complete replace "' + selectedFont + '" with ' + '"' + replaceFont + '".');
+            doc.showMessage('Complete replace of "' + selectedFont + '" with ' + '"' + replaceFont + '".');
 
         }
     } else {
-        doc.showMessage("This document don't have any text layer.");
+        doc.showMessage("This document has no text layers.");
     }
 };
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Fonts.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Fonts.cocoascript
@@ -27,7 +27,7 @@ var onRun = function(context) {
         // Dialog
         var alert = COSAlertWindow.new();
         alert.setMessageText("Replace Fonts.");
-        alert.setInformativeText("Tips: You can find the Postscript name of the font from \"Font Book\" app.")
+        alert.setInformativeText("Tips: You can find the PostScript name of the font from \"Font Book\" app.")
 
         alert.addTextLabelWithValue("Choose a font used in current document:");
 
@@ -40,7 +40,7 @@ var onRun = function(context) {
 
         var textField = NSTextField.alloc().initWithFrame(NSMakeRect(0, 0, 300, 24));
         textField.setStringValue(getPreferences(context, "replaceFont") || "");
-        textField.setPlaceholderString("Type the postscript name of the font.");
+        textField.setPlaceholderString("Type the PostScript name of the font.");
         alert.addAccessoryView(textField);
 
         alert.addButtonWithTitle("OK");
@@ -54,7 +54,7 @@ var onRun = function(context) {
 
             // Font no specified.
             if (replaceFont == "") {
-                showAlert("Font Not Specified.", "Pleace input the postscript of font you want to replace with.");
+                showAlert("Font Not Specified.", "Pleace input the PostScript of font you want to replace with.");
                 return;
             }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
@@ -8,7 +8,7 @@ var onRun = function(context) {
     var doc = context.document;
 
     if (!doc.fileURL()) {
-        doc.showMessage("This document don't have any missing fonts.");
+        doc.showMessage("This document has no missing fonts.");
         return;
     }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
@@ -35,7 +35,7 @@ var onRun = function(context) {
 
         var textField = NSTextField.alloc().initWithFrame(NSMakeRect(0, 0, 300, 24));
         textField.setStringValue(getPreferences(context, "replaceFont") || "");
-        textField.setPlaceholderString("Type the postscript name of the font.");
+        textField.setPlaceholderString("Type the PostScript name of the font.");
         alert.addAccessoryView(textField);
 
         alert.addButtonWithTitle("OK");
@@ -48,7 +48,7 @@ var onRun = function(context) {
 
             // Font no specified.
             if (replaceFont == "") {
-                showAlert("Font Not Specified.", "Pleace input the postscript of font you want to replace with.");
+                showAlert("Font Not Specified.", "Pleace input the PostScript of font you want to replace with.");
                 return;
             }
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Replace_Missing_Fonts.cocoascript
@@ -22,7 +22,7 @@ var onRun = function(context) {
         // Dialog
         var alert = COSAlertWindow.new();
         alert.setMessageText("Replace Missing Fonts.");
-        alert.setInformativeText("Tips: You can find the postscript name of font from \"Font Book\" app.")
+        alert.setInformativeText("Tips: You can find the PostScript name of the font from \"Font Book\" app.")
 
         alert.addTextLabelWithValue("Choose a missing font:");
 
@@ -86,7 +86,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("This document don't have any missing fonts.");
+        doc.showMessage("This document doesn't have any missing fonts.");
     }
 
 }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Resize_Fit_Text_Height.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Resize_Fit_Text_Height.cocoascript
@@ -52,7 +52,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one text layer.");
+        doc.showMessage("Please select at least 1 text layer.");
     }
 
     ga(context, "Type");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Unfixed_Layer_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Unfixed_Layer_Name.cocoascript
@@ -21,7 +21,7 @@ var onRun = function(context) {
         }
 
     } else {
-        doc.showMessage("Please select at least one text layer.");
+        doc.showMessage("Please select at least 1 text layer.");
     }
 
     ga(context, "Type");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Type/Unfixed_Layer_Name.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Type/Unfixed_Layer_Name.cocoascript
@@ -17,7 +17,7 @@ var onRun = function(context) {
         }
 
         if (!selectionHasTextLayer) {
-            doc.showMessage("Your selection have no contains any text layer.");
+            doc.showMessage("Your selection has no text layers.");
         }
 
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Export_Clean_Code_SVG.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Export_Clean_Code_SVG.cocoascript
@@ -19,7 +19,7 @@ var onRun = function(context) {
     // Dialog
     var dialog = UI.cosDialog(
         "Export Clean Code SVG",
-        "Export clean code SVG files from symbol masters, groups, without make a copy and remove layers.",
+        "Export clean code SVG files from symbol masters, groups, without making a copy and remove layers.",
         ["Save", "Cancel"]
     );
 
@@ -142,7 +142,7 @@ var onRun = function(context) {
                 savePanel.setCanCreateDirectories(true);
             } else {
                 savePanel = NSOpenPanel.openPanel();
-                savePanel.setMessage("Export select layers as SVG");
+                savePanel.setMessage("Export selected layers as SVG");
                 savePanel.setCanChooseDirectories(true);
                 savePanel.setCanChooseFiles(false);
                 savePanel.setCanCreateDirectories(true);
@@ -298,7 +298,7 @@ var onRun = function(context) {
             //         savePanel.setCanCreateDirectories(true);
             //     } else {
             //         savePanel = NSOpenPanel.openPanel();
-            //         savePanel.setMessage("Export select layers as SVG");
+            //         savePanel.setMessage("Export selected layers as SVG");
             //         savePanel.setCanChooseDirectories(true);
             //         savePanel.setCanChooseFiles(false);
             //         savePanel.setCanCreateDirectories(true);


### PR DESCRIPTION
Hey @Ashung I spent some time this morning cleaning up the grammar for error messages, dialogs, and confirmation messages. Some common things I found
-`Not any ___  in ___` or `No any ___ in ___`, I changed to `No ____s in ____`
- Change `at least one` to `at least 1` because the number will stand out for users better
- general spelling erros
- passive voice: `have been changed` can just be `changed`
