### PR TITLE
Added command "Select Layers Below"

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_Below.cocoascript
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_Below.cocoascript
@@ -1,0 +1,45 @@
+@import "../Libraries/Google_Analytics.cocoascript";
+
+var onRun = function(context) {
+
+    ga(context, "Layer");
+
+    var document = context.document;
+    var page = document.currentPage();
+    var selection = context.selection;
+
+    if (selection.count() == 0) {
+        document.showMessage("Please select a layer");
+        return;
+    }
+
+    // Deselect all layers
+    if (page.deselectAllLayers) {
+        page.deselectAllLayers();
+    } else {
+        page.changeSelectionBySelectingLayers(nil);
+    }
+
+    var layer = selection.firstObject();
+    var parent = layer.parentGroup();
+    var bottom = layer.frame().y();
+
+    var loop = selection.objectEnumerator();
+    while (layer = loop.nextObject()) {
+      if (layer.frame().y() > bottom) {
+        bottom = layer.frame().y(); // + layer.frame().height();
+      }
+    }
+
+    var loopChild = parent.layers().objectEnumerator();
+    var child;
+    while (child = loopChild.nextObject()) {
+      if (child.frame().y() > bottom) {
+        if (MSApplicationMetadata.metadata().appVersion < 45) {
+            child.select_byExpendingSelection(true, true);
+        } else {
+            child.select_byExtendingSelection(true, true);
+        }
+      }
+    }
+};

--- a/automate-sketch.sketchplugin/Contents/Sketch/manifest.json
+++ b/automate-sketch.sketchplugin/Contents/Sketch/manifest.json
@@ -731,6 +731,12 @@
       "icon": "icon_runner.png"
     },
     {
+      "name": "Select Layers Below",
+      "identifier": "select_layers_below",
+      "script": "Layer/Select_Layers_Below.cocoascript",
+      "icon": "icon_runner.png"
+    },
+    {
       "name": "Save Export Presets",
       "identifier": "save_export_presets",
       "handler": "saveExportPresetsToFile",
@@ -1333,6 +1339,7 @@
           "select_all_child_layers",
           "select_all_siblings_layers",
           "select_parent_groups",
+          "select_layers_below",
           "select_layers_outside_of_artboard_bounds",
           "select_reverse",
           "select_none",


### PR DESCRIPTION
Hello Ashung,
I added a command "Select Layers Below" in the "Layer" submenu to select all layers in the current scope which have a larger y-position than the current selection (aka "located below the selection"). 
It helps me a lot on tall artboards, for example long webpages or scrolling app content: you work on the height or position of one part of your design and then have to manually adjust the position of all the parts that a located below that. 

I use your plugin a lot and I thought, this command would be a nice addition to it, instead of writing my own plugin. 

Thank you and keep up the good work!
Cheers