### PR TITLE
Fix for Find and Replace Style

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Find_and_Replace_Style.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Find_and_Replace_Style.js
@@ -131,12 +131,13 @@ var onRun = function(context) {
             loadSelectMenuData(targetStyleView, localStyles, stylesInOverride);
             selectedLibrary = undefined;
         } else {
-            selectedLibrary = enabledLibraries[selectedIndex];
+            selectedLibrary = enabledLibraries[selectedIndex-1];
             if (identifier == "find_and_replace_layer_style") {
                 styleReferences = selectedLibrary.getImportableLayerStyleReferencesForDocument(document);
             } else {
                 styleReferences = selectedLibrary.getImportableTextStyleReferencesForDocument(document);
             }
+            styleReferences.sort((a,b) => a.name > b.name)
             loadSelectMenuData(targetStyleView, styleReferences, stylesInOverride);
         }
     });


### PR DESCRIPTION
Hi. Thanks for this great collection. This plugin is a big life saver for me. I did a small fix and an improvement for Find and Replace Style commands.

Styles were being listed from wrong library, I fixed that. And default sorting of importable references was a mess, I sorted them by name, now it is easier to find a style in the list.

Hope this gets merged. Many thanks again.