### PR TITLE
Use the official API to get app version. Fixes broken plugin in Sketch 72

### DIFF
--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Arrange_Objects.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Arrange_Objects.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -51,7 +53,7 @@ var onRun = function(context) {
 
             // Resize group to fit children
             if (selection.firstObject().parentGroup().class() == "MSLayerGroup") {
-                if (MSApplicationMetadata.metadata().appVersion >= 53) {
+                if (sketch.version.sketch >= 53) {
                     selection.firstObject().parentGroup().fixGeometryWithOptions(1);
                 } else {
                     selection.firstObject().parentGroup().resizeToFitChildrenWithOption(1);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Change_Places.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Change_Places.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Arrange");
 
@@ -77,7 +78,7 @@ var onRun = function(context) {
     var selectedLayer;
     while (selectedLayer = loopSelection.nextObject()) {
         if (selectedLayer.parentGroup().class() == "MSLayerGroup") {
-            if (MSApplicationMetadata.metadata().appVersion >= 53) {
+            if (sketch.version.sketch >= 53) {
                 selectedLayer.parentGroup().fixGeometryWithOptions(1);
             } else {
                 selectedLayer.parentGroup().resizeToFitChildrenWithOption(1);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Tile_Objects.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Arrange/Tile_Objects.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var tileLayersByPositionY = function(context) {
     tileLayer(context, "posy");
 };
@@ -204,7 +206,6 @@ var customTileLayers = function(context) {
 };
 
 function tileLayer(context, orientation) {
-
     var ga = require("../modules/Google_Analytics");
     ga("Arrange");
 
@@ -306,7 +307,7 @@ function tileLayer(context, orientation) {
         var selectedLayer;
         while (selectedLayer = loopSelection.nextObject()) {
             if (selectedLayer.parentGroup().class() == "MSLayerGroup") {
-                if (MSApplicationMetadata.metadata().appVersion >= 53) {
+                if (sketch.version.sketch >= 53) {
                     selectedLayer.parentGroup().fixGeometryWithOptions(1);
                 } else {
                     selectedLayer.parentGroup().resizeToFitChildrenWithOption(1);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_Navigator.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_Navigator.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -65,7 +67,6 @@ var onRun = function(context) {
 };
 
 function loadData(context, scrollView, page) {
-    var sketch = require("sketch");
     var zoom = require("../modules/Zoom");
     var ui = require("../modules/Dialog").ui;
     var artboards = page.artboards().reverseObjectEnumerator().allObjects().mutableCopy();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_to_Group.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Artboard_to_Group.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Artboard");
 
@@ -22,7 +23,7 @@ var onRun = function(context) {
             rectangle.setRect(CGRectMake(0, 0, artboard.frame().width(), artboard.frame().height()));
             
             var backgroundLayer;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 backgroundLayer = rectangle;
             } else {
                 backgroundLayer = MSShapeGroup.shapeWithPath(rectangle);
@@ -37,7 +38,7 @@ var onRun = function(context) {
         // Create new group for all layers in artboard
         var newGroup;
         var layerArray = MSLayerArray.arrayWithLayers(artboard.layers());
-        if (MSApplicationMetadata.metadata().appVersion >= 52) {
+        if (sketch.version.sketch >= 52) {
             newGroup = MSLayerGroup.groupWithLayers(layerArray);
         } else {
             newGroup = MSLayerGroup.groupFromLayers(layerArray);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Export_All_Artboards.js
@@ -1,3 +1,5 @@
+var sketch = require("sketch")
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -7,7 +9,6 @@ var onRun = function(context) {
     var ui = require("../modules/Dialog").ui;
     var system = require("../modules/System");
     var util = require("util");
-    var sketch = require("sketch");
     var document = sketch.getSelectedDocument();
     var documentData = document._getMSDocumentData();
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Move_Artboards_to_Bottom_of_Another.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Artboard/Move_Artboards_to_Bottom_of_Another.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Symbol");
 
@@ -106,7 +107,7 @@ function selectLayers(context, layers) {
 }
 
 function selectLayer(layer, add) {
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     if (appVersion < 45) {
         layer.select_byExpandingSelection(true, add);
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Development/Pick_Color_And_Copy_To_Pasteboard.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Development/Pick_Color_And_Copy_To_Pasteboard.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Development");
 
@@ -12,7 +13,7 @@ var onRun = function(context) {
     button.setCOSJSTargetFunction(function(obj) {
 
         var pickColor;
-        if (MSApplicationMetadata.metadata().appVersion >= 52) {
+        if ( sketch.version.sketch >= 52) {
             pickColor = obj.color();
         } else {
             pickColor = obj.chosenColor();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Bounds_Layer_for_Every_Selection.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Bounds_Layer_for_Every_Selection.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -91,7 +92,7 @@ var onRun = function(context) {
                 rectangle.setRect(newBounds);
 
                 var boundsLayer;
-                if (MSApplicationMetadata.metadata().appVersion >= 52) {
+                if (sketch.version.sketch >= 52) {
                     boundsLayer = rectangle;
                 } else {
                     boundsLayer = MSShapeGroup.shapeWithPath(rectangle);
@@ -102,7 +103,7 @@ var onRun = function(context) {
                 // Select boundsLayer
                 if (boundsLayer.parentGroup() != layer){
                     // Fix Sketch 45
-                    if (MSApplicationMetadata.metadata().appVersion < 45) {
+                    if (sketch.version.sketch < 45) {
                         boundsLayer.select_byExpandingSelection(true, false);
                     } else {
                         boundsLayer.select_byExtendingSelection(true, false);
@@ -125,7 +126,7 @@ var onRun = function(context) {
                 // Fix layer group bounds
                 if (layer.class() == "MSLayerGroup") {
                     // reset bounds
-                    if (MSApplicationMetadata.metadata().appVersion >= 53) {
+                    if (sketch.version.sketch >= 53) {
                         layer.fixGeometryWithOptions(1);
                     } else {
                         layer.resizeToFitChildrenWithOption(1);
@@ -141,7 +142,7 @@ var onRun = function(context) {
                         var name = layer.name();
                         layer.ungroup();
                         var newGroup;
-                        if (MSApplicationMetadata.metadata().appVersion >= 52) {
+                        if (sketch.version.sketch >= 52) {
                             newGroup = MSLayerGroup.groupWithLayers(children);
                         } else {
                             newGroup = MSLayerGroup.groupFromLayers(children);
@@ -150,7 +151,7 @@ var onRun = function(context) {
                     }
                 }
                 if (layer.parentGroup().class() == "MSLayerGroup") {
-                    if (MSApplicationMetadata.metadata().appVersion >= 53) {
+                    if (sketch.version.sketch >= 53) {
                         layer.parentGroup().fixGeometryWithOptions(1);
                     } else {
                         layer.parentGroup().resizeToFitChildrenWithOption(1);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Convert_to_Outlines.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Convert_to_Outlines.js
@@ -1,5 +1,6 @@
-var onRun = function (context) {
+var sketch = require('sketch')
 
+var onRun = function (context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -94,7 +95,7 @@ function selectSubLayer(subGroup, select) {
 
     var layerType = require("../modules/Type");
 
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
 
     var loopChildren = subGroup.children().objectEnumerator();
     while (subLayer = loopChildren.nextObject()) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Divide_Layer.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Divide_Layer.js
@@ -58,7 +58,7 @@ var onRun = function(context) {
                         cellLayer.frame().setHeight(cellHeight);
 
                         // Fix Sketch 45
-                        if (MSApplicationMetadata.metadata().appVersion < 45) {
+                        if (sketch.version.sketch < 45) {
                             cellLayer.select_byExpandingSelection(true, true);
                         } else {
                             cellLayer.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Paste_and_Replace.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Paste_and_Replace.js
@@ -1,11 +1,12 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
     var preferences = require("../modules/Preferences");
     var type = require("../modules/Type");
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     var document = context.document;
     var selection = context.selection;
     var page = document.currentPage();
@@ -139,7 +140,7 @@ var onRun = function(context) {
 };
 
 function getPasteboardLayers(context) {
-    var version = MSApplicationMetadata.metadata().appVersion;
+    var version = sketch.version.sketch;
     var pasteboard = NSPasteboard.generalPasteboard();
     var pasteboardManager = NSApp.delegate().pasteboardManager();
     var pasteboardLayers;

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Redundant_Groups.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Remove_Redundant_Groups.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -57,7 +58,7 @@ function groupIsSafeToUngroup(group) {
         noExportOptions = (group.exportOptions().exportFormats().count() == 0);
 
     // Sketch 44+ resizing constraint
-    if (MSApplicationMetadata.metadata().appVersion >= 44) {
+    if (sketch.version.sketch >= 44) {
         var noResizingConstraint = (group.resizingConstraint() == 63);
         return noOpacity && noBlending && noShadows && noResizingConstraint && noExportOptions;
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Child_Layers.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Child_Layers.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -29,7 +30,7 @@ var onRun = function(context) {
                 var child;
                 while (child = loopChild.nextObject()) {
                     // Fix Sketch 45
-                    if (MSApplicationMetadata.metadata().appVersion < 45) {
+                    if (sketch.version.sketch < 45) {
                         child.select_byExpendingSelection(true, true);
                     } else {
                         child.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Hidden_Layers.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Hidden_Layers.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -26,7 +27,7 @@ var onRun = function(context) {
 function selectHiddenLayer(layer) {
     if (!layer.isVisible()) {
         // Fix Sketch 45
-        if (MSApplicationMetadata.metadata().appVersion < 45) {
+        if (sketch.version.sketch < 45) {
             layer.select_byExpandingSelection(true, true);
         } else {
             layer.select_byExtendingSelection(true, true);
@@ -36,7 +37,7 @@ function selectHiddenLayer(layer) {
         while (childLayer = loopChildren.nextObject()) {
             if (!childLayer.isVisible()) {
                 // Fix Sketch 45
-                if (MSApplicationMetadata.metadata().appVersion < 45) {
+                if (sketch.version.sketch < 45) {
                     childLayer.select_byExpandingSelection(true, true);
                 } else {
                     childLayer.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Siblings_Layers.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_All_Siblings_Layers.js
@@ -1,5 +1,6 @@
-var onRun = function(context) {
+var sketch = require('sketch')
 
+var onRun = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Layer");
 
@@ -25,7 +26,7 @@ var onRun = function(context) {
     var loopChild = parent.layers().objectEnumerator();
     var child;
     while (child = loopChild.nextObject()) {
-        if (MSApplicationMetadata.metadata().appVersion < 45) {
+        if (sketch.version.sketch < 45) {
             child.select_byExpendingSelection(true, true);
         } else {
             child.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Layers_By_Type.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var selectAllGroupsInSelection = function(context) {
     selectLayersInSelectionByType(context, "group");
 };
@@ -30,7 +32,7 @@ var selectAllExportableInSelection = function(context) {
     var doc = context.document;
     var page = doc.currentPage();
     var selection = context.selection;
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
 
     var totalCount = 0;
 
@@ -130,7 +132,7 @@ function selectLayersInParent_byType(parent, type, callback) {
 
     var layerType = require("../modules/Type");
 
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
 
     var count = 0;
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Parent_Groups.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_Parent_Groups.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -44,7 +46,7 @@ var onRun = function(context) {
 };
 
 function selectLayer(layer) {
-    if (MSApplicationMetadata.metadata().appVersion < 45) {
+    if (sketch.version.sketch < 45) {
         layer.select_byExpendingSelection(true, true);
         if (!layer.selectedInLayerList()) {
             deselectAllChildAndSelf(layer, true);
@@ -66,7 +68,7 @@ function deselectAllChildAndSelf(layer, self) {
         if (self == false && child == layer) {
             continue;
         }
-        if (MSApplicationMetadata.metadata().appVersion < 45) {
+        if (sketch.version.sketch < 45) {
             child.select_byExpendingSelection(false, true);
         } else {
             child.select_byExtendingSelection(false, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_or_Remove_All_Transparency_Layers.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Select_or_Remove_All_Transparency_Layers.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var removeTransparencyLayersHandler = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -73,7 +75,7 @@ function selectTransparencyLayers(layer) {
     if (layer.isKindOfClass(MSStyledLayer)) {
         if (layerIsTransparency(layer)) {
             // Fix Sketch 45
-            if (MSApplicationMetadata.metadata().appVersion < 45) {
+            if (sketch.version.sketch < 45) {
                 layer.select_byExpandingSelection(true, true);
             } else {
                 layer.select_byExtendingSelection(true, true);
@@ -85,7 +87,7 @@ function selectTransparencyLayers(layer) {
                 if (childLayer.isKindOfClass(MSStyledLayer)) {
                     if (layerIsTransparency(childLayer)) {
                         // Fix Sketch 45
-                        if (MSApplicationMetadata.metadata().appVersion < 45) {
+                        if (sketch.version.sketch < 45) {
                             childLayer.select_byExpandingSelection(true, true);
                         } else {
                             childLayer.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Layer/Union_Layer.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Layer/Union_Layer.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function (context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -94,7 +96,7 @@ function selectSubLayer(subGroup, select) {
 
     var layerType = require("../modules/Type");
 
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
 
     var loopChildren = subGroup.children().objectEnumerator();
     while (subLayer = loopChildren.nextObject()) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Local_Style_to_Library_Style.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -295,7 +297,7 @@ var onRun = function(context) {
             var sharedStyle = styleToLibraryDict["" + item.objectID()];
             if (sharedStyle) {
                 item.allLayersInstances().forEach(function(layer) {
-                    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+                    if (sketch.version.sketch >= 52) {
                         var localStyleID = layer.sharedStyleID();
                         if (resetStyleView.state() == NSOffState) {
                             layer.setSharedStyleID(localStyleIDToForeignStyleMapping[localStyleID].localShareID());

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Symbols_to_Library_Symbol.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Change_Symbols_to_Library_Symbol.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -238,7 +240,7 @@ var onRun = function(context) {
 
                 // Import symbol
                 var importedSymbol;
-                if (MSApplicationMetadata.metadata().appVersion >= 50) {
+                if (sketch.version.sketch >= 50) {
                     var shareableObjectReference = MSShareableObjectReference.referenceForShareableObject_inLibrary(
                         remoteSymbol, selectedLibrary
                     );

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Fix_Library_ID_Conflict.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -8,7 +10,7 @@ var onRun = function(context) {
 
     var document = context.document;
 
-    if (MSApplicationMetadata.metadata().appVersion < 48) {
+    if (sketch.version.sketch < 48) {
         document.showMessage("😮 You have to update to Sketch 48+ to use this feature.");
         return;
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Document_Assets_from_Library.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Document_Assets_from_Library.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -7,7 +9,7 @@ var onRun = function(context) {
     var ui = require("../modules/Dialog").ui;
     var util = require("util");
     var document = context.document;
-    if (MSApplicationMetadata.metadata().appVersion < 47) {
+    if (sketch.version.sketch < 47) {
         document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Styles_from_Library.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Import_Styles_from_Library.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -7,7 +9,7 @@ var onRun = function(context) {
     var ui = require("../modules/Dialog").ui;
     var util = require("util");
     var document = context.document;
-    if (MSApplicationMetadata.metadata().appVersion < 47) {
+    if (sketch.version.sketch < 47) {
         document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Imported_Symbols_Link_Manage.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Imported_Symbols_Link_Manage.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -8,7 +10,7 @@ var onRun = function(context) {
     var ui = require("../modules/Dialog").ui;
 
     var document = context.document;
-    if (MSApplicationMetadata.metadata().appVersion < 47) {
+    if (sketch.version.sketch < 47) {
         document.showMessage("😮 You have to update to Sketch 47+ to use this feature.");
         return;
     }
@@ -35,7 +37,7 @@ var onRun = function(context) {
     var loopAllImportedSymbols = allImportedSymbols.objectEnumerator();
     var importedSymbol;
     while (importedSymbol = loopAllImportedSymbols.nextObject()) {
-        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+        if (sketch.version.sketch >= 49) {
             var libraryForSymbol = assetLibraryController.libraryForShareableObject(importedSymbol.symbolMaster());
         } else {
             var libraryForSymbol = assetLibraryController.libraryForSymbol(importedSymbol.symbolMaster());
@@ -116,7 +118,7 @@ function loadData(scrollView, symbols) {
     var i = 0;
     while (importedSymbol = loopImportedSymbols.nextObject()) {
 
-        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+        if (sketch.version.sketch >= 49) {
             var libraryForSymbol = assetLibraryController.libraryForShareableObject(importedSymbol.symbolMaster());
         } else {
             var libraryForSymbol = assetLibraryController.libraryForSymbol(importedSymbol.symbolMaster());
@@ -194,7 +196,7 @@ function loadData(scrollView, symbols) {
             var tipView = sender.superview().subviews().objectAtIndex(1);
             var importedSymbolIndex = parseInt(sender.superview().subviews().objectAtIndex(0).stringValue());
             var importedSymbol = symbols.objectAtIndex(importedSymbolIndex);
-            if (MSApplicationMetadata.metadata().appVersion >= 49) {
+            if (sketch.version.sketch >= 49) {
                 var originalLibrary = assetLibraryController.libraryForShareableObject(importedSymbol.symbolMaster());
             } else {
                 var originalLibrary = assetLibraryController.libraryForSymbol(importedSymbol.symbolMaster());

--- a/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Library/Replace_Symbol_With_Library_Symbol.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -9,7 +11,7 @@ var onRun = function(context) {
     var document = context.document;
     var documentData = document.documentData();
 
-    if (MSApplicationMetadata.metadata().appVersion < 47) {
+    if (sketch.version.sketch < 47) {
         document.showMessage("😮 You have to update to Sketch 47+ to use thie feature.");
         return;
     }
@@ -214,7 +216,7 @@ function reloadSymbolData(context, view, symbol, library, checkboxSize) {
                 }
             }
 
-            if (MSApplicationMetadata.metadata().appVersion >= 50) {
+            if (sketch.version.sketch >= 50) {
                 var shareableObjectReference = MSShareableObjectReference.referenceForShareableObject_inLibrary(
                     library.document().symbolWithID(importedSymbolID),
                     library

--- a/automate-sketch.sketchplugin/Contents/Sketch/Slice/Export_Presets.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Slice/Export_Presets.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var saveExportPresetsToFile = function(context) {
 
     var ga = require("../modules/Google_Analytics");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Colors_or_Gradients_from_Selected_Layers_to_Document.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Colors_or_Gradients_from_Selected_Layers_to_Document.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Solid_Fill_from_CSS_Color.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Add_Solid_Fill_from_CSS_Color.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var colorKeywords = {
     "black": "#000000",
     "silver": "#c0c0c0",
@@ -288,7 +290,7 @@ var onRun = function(context) {
             doc.reloadInspector();
 
             // Fix Sketch 45
-            if (MSApplicationMetadata.metadata().appVersion < 45) {
+            if (sketch.version.sketch < 45) {
                 layer.select_byExpandingSelection(true, true);
             } else {
                 layer.select_byExtendingSelection(true, true);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Color_Guide.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Color_Guide.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -7,7 +9,7 @@ var onRun = function(context) {
     var Dialog = require("../modules/Dialog").dialog;
     var ui = require("../modules/Dialog").ui;
 
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     var document = context.document;
 
     var documentColors;
@@ -59,7 +61,7 @@ var onRun = function(context) {
         var page = document.currentPage();
 
         var point;
-        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+        if (sketch.version.sketch >= 49) {
             point = page.originForNewArtboardWithSize(CGSizeMake(100,100));
         } else {
             point = page.originForNewArtboard();
@@ -117,7 +119,7 @@ var onRun = function(context) {
             var rectangle = MSRectangleShape.alloc().init();
             rectangle.setRect(CGRectMake(0, 0, paletteWidth, paletteHeight));
             var palette;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 palette = rectangle;
             } else {
                 palette = MSShapeGroup.shapeWithPath(rectangle);
@@ -207,7 +209,7 @@ function centerRect_byLayers(document, layers) {
     });
     var rect = MSRect.rectWithUnionOfRects(rects).rect();
 
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     if (appVersion >= 48) {
         document.contentDrawView().centerRect_animated(rect, true);
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Style_Guide.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Style_Guide.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -55,7 +57,7 @@ var onRun = function(context) {
         }
         preferences.set("paletteSize", userInputString.toString());
 
-        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+        if (sketch.version.sketch >= 49) {
             point = page.originForNewArtboardWithSize(CGSizeMake(paletteWidth, paletteHeight));
         } else {
             point = page.originForNewArtboard();
@@ -80,13 +82,13 @@ var onRun = function(context) {
             var rectangle = MSRectangleShape.alloc().init();
             rectangle.setRect(CGRectMake(0, 0, paletteWidth, paletteHeight));
             var palette;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 palette = rectangle;
             } else {
                 palette = MSShapeGroup.shapeWithPath(rectangle);
             }
             palette.setStyle(style.style());
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 palette.setSharedStyleID(style.objectID());
             } else {
                 palette.style().setSharedObjectID(style.objectID());
@@ -120,7 +122,7 @@ function centerRect_byLayers(document, layers) {
         return MSRect.alloc().initWithRect(item.absoluteRect().rect());
     });
     var rect = MSRect.rectWithUnionOfRects(rects).rect();
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     if (appVersion >= 48) {
         document.contentDrawView().centerRect_animated(rect, true);
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Typography_Guide.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Create_Typography_Guide.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -50,7 +52,7 @@ var onRun = function(context) {
         var page = document.sketchObject.currentPage();
 
         var point;
-        if (MSApplicationMetadata.metadata().appVersion >= 49) {
+        if (sketch.version.sketch >= 49) {
             point = page.originForNewArtboardWithSize(CGSizeMake(100,100));
         } else {
             point = page.originForNewArtboard();
@@ -97,7 +99,7 @@ var onRun = function(context) {
                 typography.setStringValue(previewText);
             }
             typography.setStyle(textStyle.style());
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 typography.setSharedStyleID(textStyle.objectID());
             } else {
                 typography.style().setSharedObjectID(textStyle.objectID());
@@ -118,7 +120,7 @@ var onRun = function(context) {
             text.frame().setY(typography.frame().height() + spaceBetweenTypographyAndText);
             typographyGroup.insertLayer_beforeLayer(text, typography);
 
-            if (MSApplicationMetadata.metadata().appVersion >= 53) {
+            if (sketch.version.sketch >= 53) {
                 typographyGroup.fixGeometryWithOptions(1);
             } else {
                 typographyGroup.resizeToFitChildrenWithOption(1);
@@ -140,7 +142,7 @@ function centerRect_byLayers(document, layers) {
         return MSRect.alloc().initWithRect(item.absoluteRect().rect());
     });
     var rect = MSRect.rectWithUnionOfRects(rects).rect();
-    var appVersion = MSApplicationMetadata.metadata().appVersion;
+    var appVersion = sketch.version.sketch;
     if (appVersion >= 48) {
         document.contentDrawView().centerRect_animated(rect, true);
     } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Import_Document_Assets_From_Sketch_File.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Import_Document_Assets_From_Sketch_File.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -24,7 +26,7 @@ var onRun = function(context) {
         return;
     }
 
-    if (MSApplicationMetadata.metadata().appVersion >= 53) {
+    if (sketch.version.sketch >= 53) {
         var assetCollection = document.documentData().assets();
         var newAssetCollection = newDocument.documentData().assets();
 

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Paste_Style_Part.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Paste_Style_Part.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -134,7 +136,7 @@ var onRun = function(context) {
                     while (layer = loopSelection.nextObject()) {
 
                         if (Sketch.isShapeLayer(layer)) {
-                            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+                            if (sketch.version.sketch >= 52) {
                                 var style = MSStyle.alloc().initWithImmutableModelObject(decoded);
                                 layer.style().setBlur(style.blur());
                             } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Remove_Unused_Styles.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -45,14 +47,14 @@ function createDialog(context, type) {
     while (page = loopPages.nextObject()) {
         var predicate;
         if (type == 0) {
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 predicate = NSPredicate.predicateWithFormat('className != "MSTextLayer" && sharedStyle.objectID != nil');
             } else {
                 predicate = NSPredicate.predicateWithFormat('className != "MSTextLayer" && style.sharedObjectID != nil')
             }
         }
         if (type == 1) {
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 predicate = NSPredicate.predicateWithFormat('className == "MSTextLayer" && sharedStyle.objectID != nil');
             } else {
                 predicate = NSPredicate.predicateWithFormat('className == "MSTextLayer" && style.sharedObjectID != nil')
@@ -63,7 +65,7 @@ function createDialog(context, type) {
         var layer;
         while (layer = loopLayers.nextObject()) {
             var style;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 style = styles.sharedObjectWithID(layer.sharedStyleID());
             } else {
                 style = styles.sharedObjectWithID(layer.style().sharedObjectID());
@@ -200,7 +202,7 @@ function createDataView(items, type, selectAll, checkedStatus) {
             var rectangle = MSRectangleShape.alloc().init();
             rectangle.setRect(CGRectMake(2, 2, 20, 20));
             var previewLayer;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 previewLayer = rectangle;
             } else {
                 previewLayer = MSShapeGroup.shapeWithPath(rectangle);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Rename_Layer_to_Style_Name.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Rename_Layer_to_Style_Name.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -8,7 +10,7 @@ var onRun = function(context) {
     var selection = context.selection;
 
     var predicate;
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (sketch.version.sketch >= 52) {
         predicate = NSPredicate.predicateWithFormat("sharedStyle.objectID != nil");
     } else {
         predicate = NSPredicate.predicateWithFormat("style.sharedObjectID != nil");
@@ -30,7 +32,7 @@ var onRun = function(context) {
         // Foreign shared style
         else {
             var sharedStyleId;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 sharedStyleId = layer.sharedStyle().objectID();
             } else {
                 sharedStyleId = layer.style().sharedObjectID();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Style/Select_Layers_by_Style.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Style/Select_Layers_by_Style.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var selectLayersByLayerStyle = function(context) {
     var ga = require("../modules/Google_Analytics");
     ga("Style");
@@ -5,7 +7,7 @@ var selectLayersByLayerStyle = function(context) {
     var documentData = document.documentData();
     var layerStyles = NSMutableArray.alloc().init();
     layerStyles.addObjectsFromArray(documentData.layerStyles().sharedStyles());
-    if (MSApplicationMetadata.metadata().appVersion >= 51) {
+    if (sketch.version.sketch >= 51) {
         layerStyles.addObjectsFromArray(documentData.foreignLayerStyles());
     }
     if (layerStyles.count() > 0) {
@@ -22,7 +24,7 @@ var selectLayersByTextStyle = function(context) {
     var documentData = document.documentData();
     var textStyles = NSMutableArray.alloc().init();
     textStyles.addObjectsFromArray(documentData.layerTextStyles().sharedStyles());
-    if (MSApplicationMetadata.metadata().appVersion >= 51) {
+    if (sketch.version.sketch >= 51) {
         textStyles.addObjectsFromArray(documentData.foreignTextStyles());
     }
     if (textStyles.count() > 0) {
@@ -111,14 +113,14 @@ function main(context, styles, title, message) {
 
         var predicate;
         if (selectedStyle.class() == "MSSharedStyle") {
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 predicate = NSPredicate.predicateWithFormat("sharedStyle.objectID == %@", selectedStyle.objectID());
             } else {
                 predicate = NSPredicate.predicateWithFormat("style.sharedObjectID == %@", selectedStyle.objectID());
             }
         }
         if (selectedStyle.class() == "MSForeignTextStyle" || selectedStyle.class() == "MSForeignLayerStyle") {
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 predicate = NSPredicate.predicateWithFormat("sharedStyleID == %@", selectedStyle.localShareID());
             } else {
                 predicate = NSPredicate.predicateWithFormat("style.sharedObjectID == %@", selectedStyle.localShareID());

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Create_Symbols_from_Selected_Layers.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Create_Symbols_from_Selected_Layers.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -35,7 +37,7 @@ var onRun = function(context) {
         if (responseCode == 1000) {
             if (sendToSymbolPage.state() == NSOnState) {
                 targetPage = documentData.symbolsPageOrCreateIfNecessary();
-                if (MSApplicationMetadata.metadata().appVersion < 54) {
+                if (sketch.version.sketch < 54) {
                     document.pageTreeLayoutDidChange();
                 }
             } else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Disable_or_Enable_All_Overrides.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Disable_or_Enable_All_Overrides.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Remove_Unused_Symbols_New.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -9,7 +11,7 @@ var onRun = function(context) {
     var document = context.document;
     var documentData = document.documentData();
 
-    if (MSApplicationMetadata.metadata().appVersion < 48) {
+    if (sketch.version.sketch < 48) {
         document.showMessage("😮 You have to update to Sketch 48+ to use thie feature.");
         return;
     }
@@ -149,7 +151,7 @@ var onRun = function(context) {
             var state = unusedSymbolView.subviews().firstObject().state();
             if (state) {
                 var unusedSymbolsWillRemoved = unusedSymbols.objectAtIndex(unusedSymbolIndex);
-                if (MSApplicationMetadata.metadata().appVersion >= 49) {
+                if (sketch.version.sketch >= 49) {
                     unusedSymbolsWillRemoved.removeFromParent();
                 } else {
                     if (unusedSymbolsWillRemoved.isForeign()) {
@@ -178,7 +180,7 @@ function getAllUnusedSymbols(context) {
     var document = context.document;
     var documentData = document.documentData();
     // In Sketch 49, unused Symbols imported from Libraries are now cleared when saving a document
-    if (MSApplicationMetadata.metadata().appVersion >= 49) {
+    if (sketch.version.sketch >= 49) {
         var allSymbols = documentData.localSymbols();
     } else {
         var allSymbols = documentData.allSymbols();

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Selection_to_Symbol.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Selection_to_Symbol.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -27,7 +29,7 @@ var onRun = function(context) {
             var rectangle = MSRectangleShape.alloc().init();
             rectangle.setRect(CGRectMake(0, 0, symbolProperties.width, symbolProperties.height));
             var tempLayer;
-            if (MSApplicationMetadata.metadata().appVersion >= 52) {
+            if (sketch.version.sketch >= 52) {
                 tempLayer = rectangle;
             } else {
                 tempLayer = MSShapeGroup.shapeWithPath(rectangle);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Set_to_Original_Width_or_Height.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Set_to_Original_Width_or_Height.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -34,7 +36,7 @@ var onRun = function(context) {
             layer.setScale(1);
 
             if (layer.parentGroup().class() == "MSLayerGroup") {
-                if (MSApplicationMetadata.metadata().appVersion >= 53) {
+                if (sketch.version.sketch >= 53) {
                     layer.parentGroup().fixGeometryWithOptions(1);
                 } else {
                     layer.parentGroup().resizeToFitChildrenWithOption(1);

--- a/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_by_Name.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Symbol/Sync_Symbol_Master_by_Name.js
@@ -1,5 +1,6 @@
 var doc = null
 var libSymbolReferences = {}
+var sketch = require('sketch')
 
 var onRun = function (context) {
 
@@ -9,7 +10,6 @@ var onRun = function (context) {
     var Dialog = require("../modules/Dialog").dialog;
     var ui = require("../modules/Dialog").ui;
     var system = require("../modules/System");
-    var sketch = require('sketch')
     var document = context.document
     doc = sketch.fromNative(document)
     var updatedCounter = 0

--- a/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Export_Clean_Code_SVG.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Export_Clean_Code_SVG.js
@@ -1,5 +1,7 @@
 @import "../Layer/Select_or_Remove_All_Transparency_Layers.js";
 
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");
@@ -292,7 +294,7 @@ var onRun = function(context) {
 
                 // Advanced Options
                 if (changeFillRule.state() == NSOnState && type.isShape(children)) {
-                    if (MSApplicationMetadata.metadata().appVersion >= 51) {
+                    if (sketch.version.sketch >= 51) {
                         children.style().setWindingRule(0);
                     }
                     else {

--- a/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Switch_Language.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/Utilities/Switch_Language.js
@@ -1,3 +1,5 @@
+var sketch = require('sketch')
+
 var onRun = function(context) {
 
     var ga = require("../modules/Google_Analytics");

--- a/automate-sketch.sketchplugin/Contents/Sketch/modules/Google_Analytics.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/modules/Google_Analytics.js
@@ -1,5 +1,5 @@
 module.exports = function(eventCategory) {
-
+    var sketch = require('sketch')
     var Dialog = require("../modules/Dialog").dialog;
 
     var identifier = __command.pluginBundle().identifier();
@@ -46,7 +46,7 @@ module.exports = function(eventCategory) {
         // Tracking ID
         url += "&tid=" + trackingID;
         // Source
-        url += "&ds=sketch" + MSApplicationMetadata.metadata().appVersion;
+        url += "&ds=sketch" + sketch.version.sketch;
         // Client ID
         url += "&cid=" + uuid;
         // User GEO location

--- a/automate-sketch.sketchplugin/Contents/Sketch/modules/Pasteboard.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/modules/Pasteboard.js
@@ -1,4 +1,4 @@
-
+var sketch = require('sketch')
 var pasteboard = NSPasteboard.generalPasteboard();
 
 module.exports.pbcopy = function(text) {
@@ -7,7 +7,7 @@ module.exports.pbcopy = function(text) {
 };
 
 module.exports.getLayers = function(context){
-    var version = MSApplicationMetadata.metadata().appVersion;
+    var version = sketch.version.sketch;
     var pasteboardManager = AppController.sharedInstance().pasteboardManager();
     var pasteboardLayers;
     if (version >= 64) {

--- a/automate-sketch.sketchplugin/Contents/Sketch/modules/Sketch.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/modules/Sketch.js
@@ -1,7 +1,8 @@
+var sketchapi = require('sketch')
 var Sketch = {};
 
 Sketch.isShapeLayer = function(layer) {
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (sketchapi.version.sketch >= 52) {
         if (
             layer.class() == "MSShapeGroup" ||
             (

--- a/automate-sketch.sketchplugin/Contents/Sketch/modules/Type.js
+++ b/automate-sketch.sketchplugin/Contents/Sketch/modules/Type.js
@@ -1,6 +1,7 @@
+var sketch = require('sketch')
 
 module.exports.isShape = function(layer) {
-    if (MSApplicationMetadata.metadata().appVersion >= 52) {
+    if (sketch.version.sketch >= 52) {
         if (
             layer.class() == "MSShapeGroup" ||
             (


### PR DESCRIPTION
I see you just merged a fix, but those changes still leave the plugin open to future breakage if you’re not using the official Javascript API. This PR should fix that.