### PR TITLE
Update release.yaml

### DIFF
--- a/_data/release.yaml
+++ b/_data/release.yaml
@@ -1,6 +1,7 @@
 -
   version: 87.1.20220513
   commitID: c29d6218744ebb4cd7b70c46186645c68225c780
+  description:
     - Add Fill Rule to Non-Zero.
     - Add Save Cloud Document to Local.
     - Fixed bugs.


### PR DESCRIPTION
Added a missing `description` key that broke the resulting `appcast.xml` file, thus breaking updates for the latest version of the plugin.

Closes #354 